### PR TITLE
Add `import_file` wrapper function

### DIFF
--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -519,7 +519,7 @@ class Client(object):
             size (int): the size of the part
             unique_id (str): a unique identifier of the data
 
-        Returns: a second in float represents elapsed time of the importing
+        Returns: second in float represents elapsed time of the importing
         """
         return self.api.import_data(db_name, table_name, format, stream, size, unique_id)
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -521,7 +521,24 @@ class Client(object):
 
         Returns: second in float represents elapsed time to import data
         """
-        return self.api.import_data(db_name, table_name, format, stream, size, unique_id)
+        return self.api.import_data(db_name, table_name, format, stream, size, unique_id=unique_id)
+
+    def import_file(self, db_name, table_name, format, file, unique_id=None):
+        """Import data into Treasure Data Service, from an existing file on filesystem.
+
+        This method will decompress/deserialize records from given file, and then
+        convert it into format acceptable from Treasure Data Service ("msgpack.gz").
+
+        Params:
+            db (str): name of a database
+            table (str): name of a table
+            format (str): format of data type (e.g. "msgpack", "json")
+            file (str or file-like): a name of a file, or a file-like object contains the data
+            unique_id (str): a unique identifier of the data
+
+        Returns: float represents the elapsed time to import data
+        """
+        return self.api.import_file(db_name, table_name, format, file, unique_id=unique_id)
 
     def results(self):
         """

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -516,10 +516,10 @@ class Client(object):
             table_name (str): name of a table
             format (str): format of data type (e.g. "msgpack.gz")
             stream (file-like): a file-like object contains the data
-            size (int): the size of the part
+            size (int): the length of the data
             unique_id (str): a unique identifier of the data
 
-        Returns: second in float represents elapsed time of the importing
+        Returns: second in float represents elapsed time to import data
         """
         return self.api.import_data(db_name, table_name, format, stream, size, unique_id)
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -508,20 +508,20 @@ class Client(object):
             return model.ScheduledJob(self, scheduled_at, job_id, type, None)
         return [ scheduled_job(m) for m in results ]
 
-    def import_data(self, db_name, table_name, format, stream, size, unique_id=None):
+    def import_data(self, db_name, table_name, format, bytes_or_stream, size, unique_id=None):
         """Import data into Treasure Data Service
 
         Params:
             db_name (str): name of a database
             table_name (str): name of a table
             format (str): format of data type (e.g. "msgpack.gz")
-            stream (file-like): a file-like object contains the data
+            bytes_or_stream (str or file-like): a byte string or a file-like object contains the data
             size (int): the length of the data
             unique_id (str): a unique identifier of the data
 
         Returns: second in float represents elapsed time to import data
         """
-        return self.api.import_data(db_name, table_name, format, stream, size, unique_id=unique_id)
+        return self.api.import_data(db_name, table_name, format, bytes_or_stream, size, unique_id=unique_id)
 
     def import_file(self, db_name, table_name, format, file, unique_id=None):
         """Import data into Treasure Data Service, from an existing file on filesystem.

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -16,7 +16,6 @@ try:
     from urllib.parse import quote as urlquote # >=3.0
 except ImportError:
     from urllib import quote as urlquote
-import warnings
 
 class ImportAPI(object):
     ####
@@ -100,14 +99,13 @@ class ImportAPI(object):
             return self.import_data(db, table, "msgpack.gz", fp, size, unique_id=unique_id)
 
     def _parse_msgpack_file(self, file):
+        # current impl doesn't torelate any unpack error
         unpacker = msgpack.Unpacker(file)
         for record in unpacker:
             yield record
 
     def _parse_json_file(self, file):
+        # current impl doesn't torelate any JSON parse error
         for s in file:
-            try:
-                record = json.loads(s)
-                yield record
-            except ValueError as error:
-                warnings.warn("skipped: %s: %s" % (error, repr(s)))
+            record = json.loads(s)
+            yield record

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -22,7 +22,7 @@ class ImportAPI(object):
     ## Import API
     ##
 
-    def import_data(self, db, table, format, stream, size, unique_id=None):
+    def import_data(self, db, table, format, bytes_or_stream, size, unique_id=None):
         """Import data into Treasure Data Service
 
         This method expects data from a file-like object formatted with "msgpack.gz".
@@ -31,7 +31,7 @@ class ImportAPI(object):
             db (str): name of a database
             table (str): name of a table
             format (str): format of data type (e.g. "msgpack.gz")
-            stream (file-like): a file-like object contains the data
+            bytes_or_stream (str or file-like): a byte string or a file-like object contains the data
             size (int): the length of the data
             unique_id (str): a unique identifier of the data
 
@@ -45,7 +45,7 @@ class ImportAPI(object):
         kwargs = {}
         if self._endpoint == self.DEFAULT_ENDPOINT:
             kwargs["endpoint"] = self.DEFAULT_IMPORT_ENDPOINT
-        with self.put(path, stream, size, **kwargs) as res:
+        with self.put(path, bytes_or_stream, size, **kwargs) as res:
             code, body = res.status, res.read()
             if code / 100 != 2:
                 self.raise_error("Import failed", res, body)

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -3,6 +3,11 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gzip
+import json
+import msgpack
+import os
+import tempfile
 try:
     import urllib.parse as urlparse # >=3.0
 except ImportError:
@@ -11,6 +16,7 @@ try:
     from urllib.parse import quote as urlquote # >=3.0
 except ImportError:
     from urllib import quote as urlquote
+import warnings
 
 class ImportAPI(object):
     ####
@@ -18,9 +24,19 @@ class ImportAPI(object):
     ##
 
     def import_data(self, db, table, format, stream, size, unique_id=None):
-        """
-        TODO: add docstring
-        => time:float
+        """Import data into Treasure Data Service
+
+        This method expects data from a file-like object formatted with "msgpack.gz".
+
+        Params:
+            db (str): name of a database
+            table (str): name of a table
+            format (str): format of data type (e.g. "msgpack.gz")
+            stream (file-like): a file-like object contains the data
+            size (int): the size of the part
+            unique_id (str): a unique identifier of the data
+
+        Returns: float represents the elapsed time to import data
         """
         if unique_id is not None:
             path = "/v3/table/import_with_id/%s/%s/%s/%s" % (urlquote(str(db)), urlquote(str(table)), urlquote(str(unique_id)), urlquote(str(format)))
@@ -37,3 +53,58 @@ class ImportAPI(object):
             js = self.checked_json(body, ["elapsed_time"])
             time = float(js["elapsed_time"])
             return time
+
+    def import_file(self, db, table, format, file, unique_id=None):
+        """Import data into Treasure Data Service, from an existing file on filesystem.
+
+        Params:
+            db (str): name of a database
+            table (str): name of a table
+            format (str): format of data type (e.g. "msgpack", "json")
+            file (str or file-like): a name of a file, or a file-like object contains the data
+            unique_id (str): a unique identifier of the data
+
+        Returns: float represents the elapsed time to import data
+        """
+        if hasattr(file, "read"):
+            if format.endswith(".gz"):
+                return self._import_file(db, table, format[0:len(format)-len(".gz")], gzip.GzipFile(fileobj=file), unique_id=unique_id)
+            else:
+                return self._import_file(db, table, format, file, unique_id=unique_id)
+        else:
+            with open(file) as fp:
+                if format.endswith(".gz"):
+                    return self._import_file(db, table, format, gzip.GzipFile(fileobj=fp), unique_id=unique_id)
+                else:
+                    return self._import_file(db, table, format, fp, unique_id=unique_id)
+
+    def _import_file(self, db, table, format, file, unique_id=None):
+        if format == "msgpack":
+            return self._import_items(db, table, self._parse_msgpack_file(file), unique_id=unique_id)
+        elif format == "json":
+            return self._import_items(db, table, self._parse_json_file(file), unique_id=unique_id)
+        else:
+            raise TypeError("unknown format: %s" % (format,))
+
+    def _import_items(self, db, table, items, unique_id=None):
+        with tempfile.TemporaryFile() as fp:
+            with gzip.GzipFile(fileobj=fp) as gz:
+                packer = msgpack.Packer()
+                for record in items:
+                    gz.write(packer.pack(record))
+            fp.seek(0)
+            size = os.fstat(fp.fileno()).st_size
+            return self.import_data(db, table, "msgpack.gz", fp, size, unique_id=unique_id)
+
+    def _parse_msgpack_file(self, file):
+        unpacker = msgpack.Unpacker(file)
+        for record in unpacker:
+            yield record
+
+    def _parse_json_file(self, file):
+        for s in file:
+            try:
+                record = json.loads(s)
+                yield record
+            except ValueError as error:
+                warnings.warn("skipped: %s: %s" % (error, repr(s)))

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -90,7 +90,7 @@ class ImportAPI(object):
 
     def _import_items(self, db, table, items, unique_id=None):
         with tempfile.TemporaryFile() as fp:
-            with gzip.GzipFile(fileobj=fp) as gz:
+            with gzip.GzipFile(mode="wb", fileobj=fp) as gz:
                 packer = msgpack.Packer()
                 for record in items:
                     gz.write(packer.pack(record))
@@ -107,5 +107,5 @@ class ImportAPI(object):
     def _parse_json_file(self, file):
         # current impl doesn't torelate any JSON parse error
         for s in file:
-            record = json.loads(s)
+            record = json.loads(s.decode("utf-8"))
             yield record

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -33,7 +33,7 @@ class ImportAPI(object):
             table (str): name of a table
             format (str): format of data type (e.g. "msgpack.gz")
             stream (file-like): a file-like object contains the data
-            size (int): the size of the part
+            size (int): the length of the data
             unique_id (str): a unique identifier of the data
 
         Returns: float represents the elapsed time to import data

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -57,6 +57,9 @@ class ImportAPI(object):
     def import_file(self, db, table, format, file, unique_id=None):
         """Import data into Treasure Data Service, from an existing file on filesystem.
 
+        This method will decompress/deserialize records from given file, and then
+        convert it into format acceptable from Treasure Data Service ("msgpack.gz").
+
         Params:
             db (str): name of a database
             table (str): name of a table
@@ -74,7 +77,7 @@ class ImportAPI(object):
         else:
             with open(file) as fp:
                 if format.endswith(".gz"):
-                    return self._import_file(db, table, format, gzip.GzipFile(fileobj=fp), unique_id=unique_id)
+                    return self._import_file(db, table, format[0:len(format)-len(".gz")], gzip.GzipFile(fileobj=fp), unique_id=unique_id)
                 else:
                     return self._import_file(db, table, format, fp, unique_id=unique_id)
 

--- a/tdclient/model.py
+++ b/tdclient/model.py
@@ -354,18 +354,18 @@ class Table(Model):
         """
         return self._client.tail(self._db_name, self._table_name, count, to, _from)
 
-    def import_data(self, format, stream, size, unique_id=None):
+    def import_data(self, format, bytes_or_stream, size, unique_id=None):
         """Import data into Treasure Data Service
 
         Params:
             format (str): format of data type (e.g. "msgpack.gz")
-            stream (file-like): a file-like object contains the data
+            bytes_or_stream (str or file-like): a byte string or a file-like object contains the data
             size (int): the length of the data
             unique_id (str): a unique identifier of the data
 
         Returns: second in float represents elapsed time to import data
         """
-        return self._client.import_data(self._db_name, self._table_name, format, stream, size, unique_id=unique_id)
+        return self._client.import_data(self._db_name, self._table_name, format, bytes_or_stream, size, unique_id=unique_id)
 
     def import_file(self, format, file, unique_id=None):
         """Import data into Treasure Data Service, from an existing file on filesystem.

--- a/tdclient/model.py
+++ b/tdclient/model.py
@@ -354,17 +354,32 @@ class Table(Model):
         """
         return self._client.tail(self._db_name, self._table_name, count, to, _from)
 
-    def import_data(self, format, stream, size):
+    def import_data(self, format, stream, size, unique_id=None):
         """Import data into Treasure Data Service
 
         Params:
             format (str): format of data type (e.g. "msgpack.gz")
             stream (file-like): a file-like object contains the data
             size (int): the length of the data
+            unique_id (str): a unique identifier of the data
 
         Returns: second in float represents elapsed time to import data
         """
-        return self._client.import_data(self._db_name, self._table_name, format, stream, size)
+        return self._client.import_data(self._db_name, self._table_name, format, stream, size, unique_id=unique_id)
+
+    def import_file(self, format, file, unique_id=None):
+        """Import data into Treasure Data Service, from an existing file on filesystem.
+
+        This method will decompress/deserialize records from given file, and then
+        convert it into format acceptable from Treasure Data Service ("msgpack.gz").
+
+        Params:
+            file (str or file-like): a name of a file, or a file-like object contains the data
+            unique_id (str): a unique identifier of the data
+
+        Returns: float represents the elapsed time to import data
+        """
+        return self._client.import_file(self._db_name, self._table_name, format, file, unique_id=unique_id)
 
     def export_data(self, storage_type, **kwargs):
         """

--- a/tdclient/model.py
+++ b/tdclient/model.py
@@ -355,8 +355,14 @@ class Table(Model):
         return self._client.tail(self._db_name, self._table_name, count, to, _from)
 
     def import_data(self, format, stream, size):
-        """
-        TODO: add docstring
+        """Import data into Treasure Data Service
+
+        Params:
+            format (str): format of data type (e.g. "msgpack.gz")
+            stream (file-like): a file-like object contains the data
+            size (int): the length of the data
+
+        Returns: second in float represents elapsed time to import data
         """
         return self._client.import_data(self._db_name, self._table_name, format, stream, size)
 

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -353,8 +353,15 @@ def test_import_data():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
     td._api.import_data = mock.MagicMock()
-    td.import_data("db_name", "table_name", "format", "stream", 123, "unique_id")
-    td.api.import_data("db_name", "table_name", "format", "stream", 123, "unique_id")
+    td.import_data("db_name", "table_name", "format", "stream", 123, unique_id="unique_id")
+    td.api.import_data("db_name", "table_name", "format", "stream", 123, unique_id="unique_id")
+
+def test_import_file():
+    td = client.Client("APIKEY")
+    td._api = mock.MagicMock()
+    td._api.import_file = mock.MagicMock()
+    td.import_file("db_name", "table_name", "format", "file", unique_id="unique_id")
+    td.api.import_file("db_name", "table_name", "format", "file", unique_id="unique_id")
 
 def test_results():
     td = client.Client("APIKEY")

--- a/tdclient/test/export_api_test.py
+++ b/tdclient/test/export_api_test.py
@@ -15,7 +15,7 @@ from tdclient.test.test_helper import *
 def setup_function(function):
     unset_environ()
 
-def test_export_success():
+def test_export_data_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump
     body = b"""
@@ -28,7 +28,7 @@ def test_export_success():
     td.post.assert_called_with("/v3/export/run/db/table", {"storage_type": "s3"})
     assert job == "12345"
 
-def test_export_failure():
+def test_export_data_failure():
     td = api.API("APIKEY")
     td.post = mock.MagicMock(return_value=make_response(500, b"error"))
     with pytest.raises(api.APIError) as error:

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -3,11 +3,15 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
+import json
+import msgpack
 try:
     from unittest import mock
 except ImportError:
     import mock
 import pytest
+import zlib
 
 from tdclient import api
 from tdclient.test.test_helper import *
@@ -15,7 +19,7 @@ from tdclient.test.test_helper import *
 def setup_function(function):
     unset_environ()
 
-def test_import_with_id_success():
+def test_import_data_with_id_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump
     body = b"""
@@ -28,7 +32,7 @@ def test_import_with_id_success():
     td.put.assert_called_with("/v3/table/import_with_id/db/table/unique_id/format", b"stream", 6, endpoint="https://api-import.treasuredata.com/")
     assert elapsed_time == 3.14
 
-def test_import_success():
+def test_import_data_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump
     body = b"""
@@ -41,9 +45,144 @@ def test_import_success():
     td.put.assert_called_with("/v3/table/import/db/table/format", b"stream", 6, endpoint="https://api-import.treasuredata.com/")
     assert elapsed_time == 2.71
 
-def test_import_failure():
+def test_import_data_failure():
     td = api.API("APIKEY")
     td.put = mock.MagicMock(return_value=make_response(500, b"error"))
     with pytest.raises(api.APIError) as error:
         td.import_data("db", "table", "format", b"stream", 6)
     assert error.value.args == ("500: Import failed: error",)
+
+def msgpackb(list):
+    """list -> bytes"""
+    stream = io.BytesIO()
+    packer = msgpack.Packer()
+    for item in list:
+        stream.write(packer.pack(item))
+    return stream.getvalue()
+
+def msgunpackb(bytes):
+    """bytes -> list"""
+    unpacker = msgpack.Unpacker(io.BytesIO(bytes))
+    return list(unpacker)
+
+def jsonb(list):
+    """list -> bytes"""
+    stream = io.BytesIO()
+    for item in list:
+        stream.write(json.dumps(item))
+        stream.write(b"\n")
+    return stream.getvalue()
+
+def unjsonb(bytes):
+    """bytes -> list"""
+    return [ json.loads(s.decode("utf-8")) for s in bytes.splitlines() ]
+    return list(unpacker)
+
+def gzipb(bytes):
+    """bytes -> bytes"""
+    compress = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
+    return compress.compress(bytes) + compress.flush()
+
+def gunzipb(bytes):
+    """bytes -> bytes"""
+    decompress = zlib.decompressobj(zlib.MAX_WBITS | 16)
+    return decompress.decompress(bytes) + decompress.flush()
+
+def test_import_file_msgpack_success():
+    td = api.API("APIKEY")
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value4", "int": 5, "float": 6.7},
+    ]
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert unique_id is None
+    td.import_data = import_data
+    stream = io.BytesIO(msgpackb(data))
+    td.import_file("db", "table", "msgpack", stream)
+
+def test_import_file_msgpack_failure():
+    td = api.API("APIKEY")
+    td.import_data = mock.MagicMock()
+    stream = io.BytesIO(b"\xc1 malformed msgpack")
+    with pytest.raises(ValueError) as error:
+        td.import_file("db", "table", "msgpack", stream)
+
+def test_import_file_msgpack_gz_success():
+    td = api.API("APIKEY")
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value4", "int": 5, "float": 6.7},
+    ]
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert unique_id is None
+    td.import_data = import_data
+    stream = io.BytesIO(gzipb(msgpackb(data)))
+    td.import_file("db", "table", "msgpack.gz", stream)
+
+def test_import_file_msgpack_gz_failure():
+    td = api.API("APIKEY")
+    td.import_data = mock.MagicMock()
+    stream = io.BytesIO(b"\xc1 malformed msgpack.gz")
+    with pytest.raises(IOError) as error:
+        td.import_file("db", "table", "msgpack.gz", stream)
+
+def test_import_file_json_success():
+    td = api.API("APIKEY")
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value4", "int": 5, "float": 6.7},
+    ]
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert unique_id is None
+    td.import_data = import_data
+    stream = io.BytesIO(jsonb(data))
+    td.import_file("db", "table", "json", stream)
+
+def test_import_file_json_failure():
+    td = api.API("APIKEY")
+    td.import_data = mock.MagicMock()
+    stream = io.BytesIO(b"malformed json")
+    with pytest.raises(ValueError) as error:
+        td.import_file("db", "table", "json", stream)
+
+def test_import_file_json_gz_success():
+    td = api.API("APIKEY")
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value4", "int": 5, "float": 6.7},
+    ]
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert unique_id is None
+    td.import_data = import_data
+    stream = io.BytesIO(gzipb(jsonb(data)))
+    td.import_file("db", "table", "json.gz", stream)
+
+def test_import_file_json_gz_failure():
+    td = api.API("APIKEY")
+    td.import_data = mock.MagicMock()
+    stream = io.BytesIO(b"malformed json.gz")
+    with pytest.raises(IOError) as error:
+        td.import_file("db", "table", "json.gz", stream)
+
+def test_import_file_unknown_format():
+    td = api.API("APIKEY")
+    td.import_data = mock.MagicMock()
+    stream = io.BytesIO(b"malformed json.gz")
+    with pytest.raises(TypeError) as error:
+        td.import_file("db", "table", "UNKNOWN", stream)

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -62,14 +62,14 @@ def msgpackb(list):
 
 def msgunpackb(bytes):
     """bytes -> list"""
-    unpacker = msgpack.Unpacker(io.BytesIO(bytes))
+    unpacker = msgpack.Unpacker(io.BytesIO(bytes), encoding=str("utf-8"))
     return list(unpacker)
 
 def jsonb(list):
     """list -> bytes"""
     stream = io.BytesIO()
     for item in list:
-        stream.write(json.dumps(item))
+        stream.write(json.dumps(item).encode("utf-8"))
         stream.write(b"\n")
     return stream.getvalue()
 


### PR DESCRIPTION
The original `import_data` requires the data to be formatted in `msgpack.gz`. I added a wrapper method named `import_file` around `import_data`. It will parse a given file and convert it into `msgpack.gz`, then upload to Treasure Data.

Because the `import_file` will decompress and unpack once and then convert into `msgpack.gz`, it's not for the best performance. Although, it would make importing data into Treasure Data easy from Python scripts.