### PR TITLE
update gitignore for JetBrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /.tox
 /build
 /dist
+
+# JetBrains IDE
+.idea/


### PR DESCRIPTION
Ignore JetBrains `.idea` directory

JetBrains IDE such as PyCharm are popular for Python development. I also use vim and PyCharm for Python development. I would like to ignore `.idea` directory.

Reference for gitignore for JetBrains IDE.
https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore

AFAIK, .idea is sufficient to ignore PyCharm.