### PR TITLE
remove unused module in the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ TreasureData API key will be read from environment variable `TD_API_KEY`, if non
 ```python
 #!/usr/bin/env python
 
-import os
-import sys
 import tdclient
 
 with tdclient.Client() as td:


### PR DESCRIPTION
Remove unused module in the example in README

According to README,

`os` and `sys` are not used.

```
#!/usr/bin/env python

import os   # NOT USED
import sys   # NOT USED
import tdclient

with tdclient.Client() as td:
    for job in td.jobs():
        print(job.job_id)
```



NOTE:
TD site has the similar mistake.
http://docs.treasuredata.com/articles/rest-api-python-client

In Issue Queries

```
import os
import tdclient
import time
apikey = os.getenv("TD_API_KEY")
with tdclient.Client(apikey) as client:
    job = client.query("sample_datasets", "SELECT COUNT(1) FROM www_access")
    # sleep until job's finish
    job.wait()
    for row in job.result():
        print(row)
```

`time` is not needed.