### PR TITLE
BigInt as string

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -411,10 +411,10 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, DatabaseAPI, ExportAPI, I
             s = s.decode(encoding) if py2k else s
             try:
                 return int(s)
-            except ValueError:
+            except (OverflowError, ValueError):
                 try:
                     return float(s)
-                except ValueError:
+                except (OverflowError, ValueError):
                     pass
             lower = s.lower()
             if lower in ("false", "true"):

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -355,7 +355,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, DatabaseAPI, ExportAPI, I
                 for item in items:
                     try:
                         mp = packer.pack(item)
-                    except OverflowError:
+                    except (OverflowError, msgpack.PackValueError):
                         packer.reset()
                         mp = packer.pack(normalized_msgpack(item))
                     gz.write(mp)

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -364,7 +364,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, DatabaseAPI, ExportAPI, I
     def _normalize_value(self, value):
         if isinstance(value, int):
             return value if value < (1<<64) else str(value)
-        elif isinstance(value, list) or isinstance(value, tuple):
+        elif isinstance(value, (list, tuple)):
             return [ self._normalize_value(v) for v in value ]
         elif isinstance(value, dict):
             return dict([ (self._normalize_value(k), self._normalize_value(v)) for (k, v) in value.items() ])

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -235,8 +235,8 @@ def test_import_file_tsv_success():
 def test_import_file_csv_dict_success():
     td = api.API("APIKEY")
     data = [
-        {"time": int(time.time()), "str": "value1", "int": 1, "float": 2.3},
-        {"time": int(time.time()), "str": "value4", "int": 5, "float": 6.7},
+        {"time": int(time.time()), "str": "value1", "int": 1, "float": 2.3, "bigint": (1<<1024 * 1<<1024)},
+        {"time": int(time.time()), "str": "value4", "int": 5, "float": 6.7, "bigint": (1<<1024 * 1<<1024)},
     ]
     def import_data(db, table, format, stream, size, unique_id=None):
         assert db == "db"

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -235,8 +235,8 @@ def test_import_file_tsv_success():
 def test_import_file_csv_dict_success():
     td = api.API("APIKEY")
     data = [
-        {"time": int(time.time()), "str": "value1", "int": 1, "float": 2.3, "bigint": (1<<1024 * 1<<1024)},
-        {"time": int(time.time()), "str": "value4", "int": 5, "float": 6.7, "bigint": (1<<1024 * 1<<1024)},
+        {"time": int(time.time()), "str": "value1", "int": 1, "float": 2.3},
+        {"time": int(time.time()), "str": "value4", "int": 5, "float": 6.7},
     ]
     def import_data(db, table, format, stream, size, unique_id=None):
         assert db == "db"

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -74,13 +74,13 @@ def test_import_file_msgpack_bigint_as_string():
     td = api.API("APIKEY")
     data = [
         {"time": int(time.time()), "int": 64, "bigint": 1<<64},
-        {"time": int(time.time()), "int": 128, "gitint": 1<<128},
+        {"time": int(time.time()), "int": 128, "bigint": 1<<128},
     ]
     def import_data(db, table, format, stream, size, unique_id=None):
         assert db == "db"
         assert table == "table"
         assert format == "msgpack.gz"
-        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert msgunpackb(gunzipb(stream.read(size))) == msgunpackb(msgpackb(data))
         assert unique_id is None
     td.import_data = import_data
     stream = io.BytesIO(msgpackb(data))

--- a/tdclient/test/import_api_test.py
+++ b/tdclient/test/import_api_test.py
@@ -70,6 +70,22 @@ def test_import_file_msgpack_success():
     stream = io.BytesIO(msgpackb(data))
     td.import_file("db", "table", "msgpack", stream)
 
+def test_import_file_msgpack_bigint_as_string():
+    td = api.API("APIKEY")
+    data = [
+        {"time": int(time.time()), "int": 64, "bigint": 1<<64},
+        {"time": int(time.time()), "int": 128, "gitint": 1<<128},
+    ]
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        assert msgunpackb(gunzipb(stream.read(size))) == data
+        assert unique_id is None
+    td.import_data = import_data
+    stream = io.BytesIO(msgpackb(data))
+    td.import_file("db", "table", "msgpack", stream)
+
 def test_import_file_msgpack_file_success():
     td = api.API("APIKEY")
     data = [

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -62,7 +62,7 @@ def msgpackb(lis):
     for item in lis:
         try:
             mp = packer.pack(item)
-        except OverflowError:
+        except (OverflowError, msgpack.PackValueError):
             packer.reset()
             mp = packer.pack(normalized_msgpack(item))
         stream.write(mp)

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -82,10 +82,10 @@ def unjsonb(bytes):
 def value(s):
     try:
         return int(s)
-    except ValueError:
+    except (OverflowError, ValueError):
         try:
             return float(s)
-        except ValueError:
+        except (OverflowError, ValueError):
             pass
     lower = s.lower()
     if lower in ("false", "true"):


### PR DESCRIPTION
msgpack's integer cannot exceed 64bit. During importing data, current implementation will raise `OverflowError` on packing data into `msgpack.gz` if there is `long` value.

As a workaround, as same as [td toolbelt](https://github.com/treasure-data/td) is doing, pack those values in string.

```
>>> import msgpack
>>> msgpack.packb(1<<64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yyuu/.pyenv/versions/3.4.3/lib/python3.4/site-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 223, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:223)
  File "msgpack/_packer.pyx", line 225, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:225)
  File "msgpack/_packer.pyx", line 140, in msgpack._packer.Packer._pack (msgpack/_packer.cpp:140)
OverflowError: Python int too large to convert to C unsigned long
```