### PR TITLE
avoid an exception raised when "start" is nil

### DIFF
--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import datetime
 try:
     from urllib.parse import quote as urlquote # >=3.0
 except ImportError:
@@ -25,10 +26,7 @@ class ScheduleAPI(object):
             if code != 200:
                 self.raise_error("Create schedule failed", res, body)
             js = self.checked_json(body, ["start"])
-            if js["start"] is None:
-                return ""
-            else:
-                return self._parsedate(js["start"], "%Y-%m-%d %H:%M:%S %Z")
+            return self._parsedate(self.get_or_else(js, "start", "1970-01-01T00:00:00Z"), "%Y-%m-%d %H:%M:%S %Z")
 
     def delete_schedule(self, name):
         """

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -25,7 +25,10 @@ class ScheduleAPI(object):
             if code != 200:
                 self.raise_error("Create schedule failed", res, body)
             js = self.checked_json(body, ["start"])
-            return self._parsedate(js["start"], "%Y-%m-%d %H:%M:%S %Z")
+            if js["start"] is None:
+                return ""
+            else:
+                return self._parsedate(js["start"], "%Y-%m-%d %H:%M:%S %Z")
 
     def delete_schedule(self, name):
         """

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import datetime
 try:
     from urllib.parse import quote as urlquote # >=3.0
 except ImportError:

--- a/tdclient/test/schedule_api_test.py
+++ b/tdclient/test/schedule_api_test.py
@@ -45,7 +45,13 @@ def test_create_schedule_without_cron_success():
     td.post = mock.MagicMock(return_value=make_response(200, body))
     start = td.create_schedule("bar", {"type": "presto", "cron": ""})
     td.post.assert_called_with("/v3/schedule/create/bar", {"type": "presto", "cron": ""})
-    assert start == ""
+    assert start.year == 1970
+    assert start.month == 1
+    assert start.day == 1
+    assert start.hour == 0
+    assert start.minute == 0
+    assert start.second == 0
+    assert start.utcoffset().seconds == 0 # UTC
 
 def test_delete_schedule_success():
     td = api.API("APIKEY")

--- a/tdclient/test/schedule_api_test.py
+++ b/tdclient/test/schedule_api_test.py
@@ -34,6 +34,19 @@ def test_create_schedule_success():
     assert start.second == 51
     assert start.utcoffset().seconds == 0 # UTC
 
+def test_create_schedule_without_cron_success():
+    td = api.API("APIKEY")
+    # TODO: should be replaced by wire dump
+    body = b"""
+        {
+            "start": null
+        }
+    """
+    td.post = mock.MagicMock(return_value=make_response(200, body))
+    start = td.create_schedule("bar", {"type": "presto", "cron": ""})
+    td.post.assert_called_with("/v3/schedule/create/bar", {"type": "presto", "cron": ""})
+    assert start == ""
+
 def test_delete_schedule_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump


### PR DESCRIPTION
I got an exception when I created a schedule with 'cron' = ''.  This is a valid schedule meaning that the query is not scheduled to run.

```python
In [1]: import tdclient

In [2]: c = tdclient.Client()

In [3]: c.create_schedule('test1', {'database': 'db1', 'cron': '', 'query': 'select 1'})
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-28-82b4b391c57e> in <module>()
----> 1 c.create_schedule('test1', {'database': 'db1', 'cron': '', 'query': 'select 1'})

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/tdclient/client.py in create_schedule(self, name, params)
    511             raise ValueError("'query' option is required")
    512         params = {} if params is None else params
--> 513         return self.api.create_schedule(name, params)
    514
    515     def delete_schedule(self, name):

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/tdclient/schedule_api.py in create_schedule(self, name, params)
     26                 self.raise_error("Create schedule failed", res, body)
     27             js = self.checked_json(body, ["start"])
---> 28             return self._parsedate(js["start"], "%Y-%m-%d %H:%M:%S %Z")
     29
     30     def delete_schedule(self, name):

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/tdclient/api.py in _parsedate(self, s, fmt)
    337         # TODO: parse datetime with using format string
    338         # for now, this ignores given format string since API may return date in ambiguous format :(
--> 339         return dateutil.parser.parse(s)
    340
    341     def get_or_else(self, hashmap, key, default_value=None):

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in parse(timestr, parserinfo, **kwargs)
   1006         return parser(parserinfo).parse(timestr, **kwargs)
   1007     else:
-> 1008         return DEFAULTPARSER.parse(timestr, **kwargs)
   1009
   1010

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in parse(self, timestr, default, ignoretz, tzinfos, **kwargs)
    390             res, skipped_tokens = self._parse(timestr, **kwargs)
    391         else:
--> 392             res = self._parse(timestr, **kwargs)
    393
    394         if res is None:

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in _parse(self, timestr, dayfirst, yearfirst, fuzzy, fuzzy_with_tokens)
    490
    491         res = self._result()
--> 492         l = _timelex.split(timestr)         # Splits the timestr into tokens
    493
    494         # keep up with the last token skipped so we can recombine

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in split(cls, s)
    172
    173     def split(cls, s):
--> 174         return list(cls(s))
    175     split = classmethod(split)
    176

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in __next__(self)
    162
    163     def __next__(self):
--> 164         token = self.get_token()
    165         if token is None:
    166             raise StopIteration

/Users/knishida/miniconda/envs/pandas3/lib/python3.4/site-packages/dateutil/parser.py in get_token(self)
     80                 nextchar = self.charstack.pop(0)
     81             else:
---> 82                 nextchar = self.instream.read(1)
     83                 while nextchar == '\x00':
     84                     nextchar = self.instream.read(1)

AttributeError: 'NoneType' object has no attribute 'read'
```

With this patch, create_schedule returns '' (empty string) when cron is ''.  There might be a better value than ''.  The API probably should return a Python object or JSON object instead of start time, but it breaks compatibility.

```python
In [1]: import tdclient

In [2]: c = tdclient.Client()

In [3]: c.create_schedule('test3', {'database': 'db1', 'cron': '', 'query': 'select 1'})
Out[3]: ''
```
