### PR TITLE
fix getting database names of job objects

### DIFF
--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -250,7 +250,7 @@ class Client(object):
                 priority=d.get("priority"),
                 retry_limit=d.get("retry_limit"),
                 org_name=d.get("org_name"),
-                db_name=d.get("db_name"),
+                database=d.get("database"),
             )
         return [ job(d) for d in results ]
 
@@ -281,7 +281,7 @@ class Client(object):
             priority=d.get("priority"),
             retry_limit=d.get("retry_limit"),
             org_name=d.get("org_name"),
-            db_name=d.get("db_name"),
+            database=d.get("database"),
         )
 
     def job_status(self, job_id):

--- a/tdclient/job_model.py
+++ b/tdclient/job_model.py
@@ -90,7 +90,7 @@ class Job(Model):
         self._priority = data.get("priority")
         self._retry_limit = data.get("retry_limit")
         self._org_name = data.get("org_name")
-        self._db_name = data.get("db_name")
+        self._database = data.get("database")
 
     def update(self):
         """Update all fields of the job
@@ -176,11 +176,11 @@ class Job(Model):
         return self._org_name
 
     @property
-    def db_name(self):
+    def database(self):
         """
         Returns: a string represents the name of a database that job is running on
         """
-        return self._db_name
+        return self._database
 
     @property
     def debug(self):

--- a/tdclient/test/job_model_test.py
+++ b/tdclient/test/job_model_test.py
@@ -19,7 +19,7 @@ def setup_function(function):
 
 def test_schema():
     client = mock.MagicMock()
-    job = models.Job(client, "job_id", "type", "query", status="status", url="url", debug="debug", start_at="start_at", end_at="end_at", cpu_time="cpu_time", result_size="result_size", result="result", result_url="result_url", hive_result_schema=[["_c1", "string"], ["_c2", "bigint"]], priority="UNKNOWN", retry_limit="retry_limit", org_name="org_name", db_name="db_name")
+    job = models.Job(client, "job_id", "type", "query", status="status", url="url", debug="debug", start_at="start_at", end_at="end_at", cpu_time="cpu_time", result_size="result_size", result="result", result_url="result_url", hive_result_schema=[["_c1", "string"], ["_c2", "bigint"]], priority="UNKNOWN", retry_limit="retry_limit", org_name="org_name", database="database")
     assert job.id == "job_id"
     assert job.job_id == "job_id"
     assert job.type == "type"
@@ -27,7 +27,7 @@ def test_schema():
     assert job.priority == "UNKNOWN"
     assert job.retry_limit == "retry_limit"
     assert job.org_name == "org_name"
-    assert job.db_name == "db_name"
+    assert job.database == "database"
     assert job.result_schema == [["_c1", "string"], ["_c2", "bigint"]]
 
 def test_job_priority():


### PR DESCRIPTION
Database name of a job is accessible by 'database', not 'db_name':

https://github.com/treasure-data/td-client-python/blob/master/tdclient/job_api.py#L84

I confirmed this patch fixes the issue:

```python
In [1]: import tdclient

In [2]: c = tdclient.Client()

In [3]: j = c.job(42334874)

In [4]: j.database
Out[4]: 'production'
```

This patch breaks backward compatibility, but I think it's acceptable because the old code have never worked.
