### PR TITLE
Handle request parameters of DataConnector jobs properly

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -146,10 +146,9 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
     def endpoint(self):
         return self._endpoint
 
-    def get(self, path, params=None, **kwargs):
-        headers = {
-            "accept-encoding": "deflate, gzip",
-        }
+    def get(self, path, params=None, headers=None, **kwargs):
+        headers = {} if headers is None else dict(headers)
+        headers["accept-encoding"] = "deflate, gzip"
         url, headers = self.build_request(path=path, headers=headers, **kwargs)
 
         log.debug("REST GET call:\n  headers: %s\n  path: %s\n  params: %s", repr(headers), repr(path), repr(params))
@@ -184,8 +183,9 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
 
         return contextlib.closing(response)
 
-    def post(self, path, params=None, **kwargs):
-        url, headers = self.build_request(path=path, headers={}, **kwargs)
+    def post(self, path, params=None, headers=None, **kwargs):
+        headers = {} if headers is None else dict(headers)
+        url, headers = self.build_request(path=path, headers=headers, **kwargs)
 
         log.debug("REST POST call:\n  headers: %s\n  path: %s\n  params: %s", repr(headers), repr(path), repr(params))
 
@@ -233,8 +233,8 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
 
         return contextlib.closing(response)
 
-    def put(self, path, bytes_or_stream, size, **kwargs):
-        headers = {}
+    def put(self, path, bytes_or_stream, size, headers=None, **kwargs):
+        headers = {} if headers is None else dict(headers)
         headers["content-length"] = str(size)
         headers["content-type"] = "application/octet-stream"
         url, headers = self.build_request(path=path, headers=headers, **kwargs)

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -18,7 +18,11 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
-        with self.post("/v3/bulk_loads/guess", job) as res:
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
+        payload = json.dumps(job).encode("utf-8") if isinstance(job, dict) else job
+        with self.post("/v3/bulk_loads/guess", payload, headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnector configuration guess failed", res, body)
@@ -28,7 +32,11 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
-        with self.post("/v3/bulk_loads/preview", job) as res:
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
+        payload = json.dumps(job).encode("utf-8") if isinstance(job, dict) else job
+        with self.post("/v3/bulk_loads/preview", payload, headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnector job preview failed", res, body)
@@ -38,10 +46,14 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
         params = dict(job)
         params["database"] = db
         params["table"] = table
-        with self.post("/v3/job/issue/bulkload/%s" % (urlquote(str(db))), params) as res:
+        payload = json.dumps(params).encode("utf-8")
+        with self.post("/v3/job/issue/bulkload/%s" % (urlquote(str(db))), payload, headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnector job issuing failed", res, body)
@@ -63,12 +75,16 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
         params = {} if params is None else dict(params)
         params.update(job)
         params["name"] = name
         params["database"] = database
         params["table"] = table
-        with self.post("/v3/bulk_loads", params) as res:
+        payload = json.dumps(params).encode("utf-8")
+        with self.post("/v3/bulk_loads", payload, headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnectorSession: %s created failed" % (name,), res, body)
@@ -88,7 +104,11 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
-        with self.put("/v3/bulk_loads/%s" % (urlquote(str(name)),), job) as res:
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
+        payload = json.dumps(job).encode("utf-8")
+        with self.put("/v3/bulk_loads/%s" % (urlquote(str(name)),), payload, len(payload), headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnectorSession: %s update failed" % (name,), res, body)
@@ -108,17 +128,21 @@ class ConnectorAPI(object):
         """
         TODO: add docstring
         """
-        with self.get("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
+        with self.get("/v3/bulk_loads/%s/jobs" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("history of DataConnectorSession: %s retrieve failed" % (name,), res, body)
-            return self.checked_json(body, [])
+            return json.loads(body.decode("utf-8"))
 
     def connector_run(self, name, **kwargs):
         """
         TODO: add docstring
         """
-        with self.post("/v3/bulk_loads/%s" % (urlquote(str(name)),), kwargs) as res:
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+        }
+        payload = json.dumps(kwargs).encode("utf-8")
+        with self.post("/v3/bulk_loads/%s/jobs" % (urlquote(str(name)),), payload, headers=headers) as res:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("DataConnectorSession: %s job create failed" % (name,), res, body)

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -21,7 +21,7 @@ class ConnectorAPI(object):
         with self.post("/v3/bulk_loads/guess", job) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoad configuration guess failed", res, body)
+                self.raise_error("DataConnector configuration guess failed", res, body)
             return self.checked_json(body, [])
 
     def connector_preview(self, job):
@@ -31,7 +31,7 @@ class ConnectorAPI(object):
         with self.post("/v3/bulk_loads/preview", job) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoad job preview failed", res, body)
+                self.raise_error("DataConnector job preview failed", res, body)
             return self.checked_json(body, [])
 
     def connector_issue(self, db, table, job):
@@ -44,7 +44,7 @@ class ConnectorAPI(object):
         with self.post("/v3/job/issue/bulkload/%s" % (urlquote(str(db))), params) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoad job issuing failed", res, body)
+                self.raise_error("DataConnector job issuing failed", res, body)
             js = self.checked_json(body, ["job_id"])
             return str(js["job_id"])
 
@@ -55,7 +55,7 @@ class ConnectorAPI(object):
         with self.get("/v3/bulk_loads") as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession list retrieve failed", res, body)
+                self.raise_error("DataConnectorSession list retrieve failed", res, body)
             # cannot use `checked_json` since `GET /v3/bulk_loads` returns an array
             return json.loads(body.decode("utf-8"))
 
@@ -71,7 +71,7 @@ class ConnectorAPI(object):
         with self.post("/v3/bulk_loads", params) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession: %s created failed" % (name,), res, body)
+                self.raise_error("DataConnectorSession: %s created failed" % (name,), res, body)
             return self.checked_json(body, [])
 
     def connector_show(self, name):
@@ -81,7 +81,7 @@ class ConnectorAPI(object):
         with self.get("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession: %s retrieve failed" % (name,), res, body)
+                self.raise_error("DataConnectorSession: %s retrieve failed" % (name,), res, body)
             return self.checked_json(body, [])
 
     def connector_update(self, name, job):
@@ -91,7 +91,7 @@ class ConnectorAPI(object):
         with self.put("/v3/bulk_loads/%s" % (urlquote(str(name)),), job) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession: %s update failed" % (name,), res, body)
+                self.raise_error("DataConnectorSession: %s update failed" % (name,), res, body)
             return self.checked_json(body, [])
 
     def connector_delete(self, name):
@@ -101,7 +101,7 @@ class ConnectorAPI(object):
         with self.delete("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession: %s delete failed" % (name,), res, body)
+                self.raise_error("DataConnectorSession: %s delete failed" % (name,), res, body)
             return self.checked_json(body, [])
 
     def connector_history(self, name):
@@ -111,7 +111,7 @@ class ConnectorAPI(object):
         with self.get("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("history of BulkLoadSession: %s retrieve failed" % (name,), res, body)
+                self.raise_error("history of DataConnectorSession: %s retrieve failed" % (name,), res, body)
             return self.checked_json(body, [])
 
     def connector_run(self, name, **kwargs):
@@ -121,5 +121,5 @@ class ConnectorAPI(object):
         with self.post("/v3/bulk_loads/%s" % (urlquote(str(name)),), kwargs) as res:
             code, body = res.status, res.read()
             if code != 200:
-                self.raise_error("BulkLoadSession: %s job create failed" % (name,), res, body)
+                self.raise_error("DataConnectorSession: %s job create failed" % (name,), res, body)
             return self.checked_json(body, [])

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -16,7 +16,10 @@ class ConnectorAPI(object):
 
     def connector_guess(self, job):
         """
-        TODO: add docstring
+        Params:
+          job (dict): :class:`dict` representation of `seed.yml`
+
+        Returns: :class:`dict`
         """
         headers = {
             "content-type": "application/json; charset=utf-8",
@@ -30,7 +33,10 @@ class ConnectorAPI(object):
 
     def connector_preview(self, job):
         """
-        TODO: add docstring
+        Params:
+          job (dict): :class:`dict` representation of `load.yml`
+
+        Returns: :class:`dict`
         """
         headers = {
             "content-type": "application/json; charset=utf-8",
@@ -44,7 +50,12 @@ class ConnectorAPI(object):
 
     def connector_issue(self, db, table, job):
         """
-        TODO: add docstring
+        Params:
+          db (str): name of the database to perform connector job
+          table (str): name of the table to perform connector job
+          job (dict): :class:`dict` representation of `load.yml`
+
+        Returns: jobId:str
         """
         headers = {
             "content-type": "application/json; charset=utf-8",
@@ -62,7 +73,7 @@ class ConnectorAPI(object):
 
     def connector_list(self):
         """
-        TODO: add docstring
+        Returns: :class:`list`
         """
         with self.get("/v3/bulk_loads") as res:
             code, body = res.status, res.read()
@@ -73,7 +84,13 @@ class ConnectorAPI(object):
 
     def connector_create(self, name, database, table, job, params=None):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+          database (str): name of the database to perform connector job
+          table (str): name of the table to perform connector job
+          job (dict): :class:`dict` representation of `load.yml`
+
+        Returns: :class:`dict`
         """
         headers = {
             "content-type": "application/json; charset=utf-8",
@@ -92,7 +109,10 @@ class ConnectorAPI(object):
 
     def connector_show(self, name):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+
+        Returns: :class:`dict`
         """
         with self.get("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
@@ -102,7 +122,11 @@ class ConnectorAPI(object):
 
     def connector_update(self, name, job):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+          job (dict): :class:`dict` representation of `load.yml`
+
+        Returns: :class:`dict`
         """
         headers = {
             "content-type": "application/json; charset=utf-8",
@@ -116,7 +140,10 @@ class ConnectorAPI(object):
 
     def connector_delete(self, name):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+
+        Returns: :class:`dict`
         """
         with self.delete("/v3/bulk_loads/%s" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
@@ -126,7 +153,10 @@ class ConnectorAPI(object):
 
     def connector_history(self, name):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+
+        Returns: :class:`list`
         """
         with self.get("/v3/bulk_loads/%s/jobs" % (urlquote(str(name)),)) as res:
             code, body = res.status, res.read()
@@ -136,7 +166,10 @@ class ConnectorAPI(object):
 
     def connector_run(self, name, **kwargs):
         """
-        TODO: add docstring
+        Params:
+          name (str): name of the connector job
+
+        Returns: :class:`dict`
         """
         headers = {
             "content-type": "application/json; charset=utf-8",

--- a/tdclient/test/connector_api_test.py
+++ b/tdclient/test/connector_api_test.py
@@ -70,19 +70,22 @@ config = {
     },
 }
 
+def dumps(x):
+    return json.dumps(x).encode("utf-8")
+
 def test_connector_guess_success():
     td = api.API("APIKEY")
-    td.post = mock.MagicMock(return_value=make_response(200, json.dumps(config).encode("utf-8")))
+    td.post = mock.MagicMock(return_value=make_response(200, dumps(config)))
     res = td.connector_guess(seed)
     assert res == config
-    td.post.assert_called_with("/v3/bulk_loads/guess", seed)
+    td.post.assert_called_with("/v3/bulk_loads/guess", dumps(seed), headers={"content-type": "application/json; charset=utf-8"})
 
 def test_connector_preview_success():
     td = api.API("APIKEY")
     body = b"{}"
     td.post = mock.MagicMock(return_value=make_response(200, body))
     td.connector_preview(config)
-    td.post.assert_called_with("/v3/bulk_loads/preview", config)
+    td.post.assert_called_with("/v3/bulk_loads/preview", dumps(config), headers={"content-type": "application/json; charset=utf-8"})
 
 def test_connector_issue_success():
     td = api.API("APIKEY")
@@ -95,7 +98,7 @@ def test_connector_issue_success():
     req = dict(config)
     req["database"] = "database"
     req["table"] = "table"
-    td.post.assert_called_with("/v3/job/issue/bulkload/database", req)
+    td.post.assert_called_with("/v3/job/issue/bulkload/database", dumps(req), headers={"content-type": "application/json; charset=utf-8"})
 
 def test_connector_list_success():
     td = api.API("APIKEY")
@@ -113,7 +116,7 @@ def test_connector_create_success():
     req["name"] = "name"
     req["database"] = "database"
     req["table"] = "table"
-    td.post.assert_called_with("/v3/bulk_loads", req)
+    td.post.assert_called_with("/v3/bulk_loads", dumps(req), headers={"content-type": "application/json; charset=utf-8"})
 
 def test_connector_show_success():
     td = api.API("APIKEY")
@@ -127,7 +130,7 @@ def test_connector_update_success():
     body = b"{}"
     td.put = mock.MagicMock(return_value=make_response(200, body))
     td.connector_update("name", config)
-    td.put.assert_called_with("/v3/bulk_loads/name", config)
+    td.put.assert_called_with("/v3/bulk_loads/name", dumps(config), len(dumps(config)), headers={"content-type": "application/json; charset=utf-8"})
 
 def test_connector_delete_success():
     td = api.API("APIKEY")
@@ -138,14 +141,14 @@ def test_connector_delete_success():
 
 def test_connector_history_success():
     td = api.API("APIKEY")
-    body = b"{}"
+    body = b"[]"
     td.get = mock.MagicMock(return_value=make_response(200, body))
     td.connector_history("name")
-    td.get.assert_called_with("/v3/bulk_loads/name")
+    td.get.assert_called_with("/v3/bulk_loads/name/jobs")
 
 def test_connector_run_success():
     td = api.API("APIKEY")
     body = b"{}"
     td.post = mock.MagicMock(return_value=make_response(200, body))
     td.connector_run("name", scheduled_time="scheduled_time")
-    td.post.assert_called_with("/v3/bulk_loads/name", {"scheduled_time": "scheduled_time"})
+    td.post.assert_called_with("/v3/bulk_loads/name/jobs", dumps({"scheduled_time": "scheduled_time"}), headers={"content-type": "application/json; charset=utf-8"})


### PR DESCRIPTION
DataConnector's request parameter is nested dictionary of JSON. It should be sent as request body with `Content-Type: application/json`.