### PR TITLE
Use keyword arguments for initializing model attributes

### DIFF
--- a/tdclient/account_api.py
+++ b/tdclient/account_api.py
@@ -20,13 +20,13 @@ class AccountAPI(object):
                 self.raise_error("Show account failed", res, body)
             js = self.checked_json(body, ["account"])
             a = js["account"]
-            account_id = int(a["id"])
-            plan = int(a["plan"])
-            storage_size = int(a["storage_size"])
-            guaranteed_cores = int(a["guaranteed_cores"])
-            maximum_cores = int(a["maximum_cores"])
-            created_at = self._parsedate(a["created_at"], "%Y-%m-%d")
-            return [account_id, plan, storage_size, guaranteed_cores, maximum_cores, created_at]
+            a["id"] = int(a["id"])
+            a["plan"] = int(a["plan"])
+            a["storage_size"] = int(a["storage_size"])
+            a["guaranteed_cores"] = int(a["guaranteed_cores"])
+            a["maximum_cores"] = int(a["maximum_cores"])
+            a["created_at"] = self._parsedate(a["created_at"], "%Y-%m-%d")
+            return a
 
     def account_core_utilization(self, _from, to):
         """

--- a/tdclient/account_model.py
+++ b/tdclient/account_model.py
@@ -9,14 +9,14 @@ class Account(Model):
     """Account on Treasure Data Service
     """
 
-    def __init__(self, client, account_id, plan, storage_size=None, guaranteed_cores=None, maximum_cores=None, created_at=None):
+    def __init__(self, client, _id, _plan, **kwargs):
         super(Account, self).__init__(client)
-        self._account_id = account_id
-        self._plan = plan
-        self._storage_size = storage_size
-        self._guaranteed_cores = guaranteed_cores
-        self._maximum_cores = maximum_cores
-        self._created_at = created_at
+        self._account_id = _id
+        self._plan = _plan
+        self._storage_size = kwargs.get("storage_size")
+        self._guaranteed_cores = kwargs.get("guaranteed_cores")
+        self._maximum_cores = kwargs.get("maximum_cores")
+        self._created_at = kwargs.get("created_at")
 
     @property
     def account_id(self):

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -64,8 +64,8 @@ class Client(object):
         """
         Returns: :class:`tdclient.models.Acount`
         """
-        account_id, plan, storage, guaranteed_cores, maximum_cores, created_at = self.api.show_account()
-        return models.Account(self, account_id, plan, storage, guaranteed_cores, maximum_cores, created_at)
+        account = self.api.show_account()
+        return models.Account(self, account.get("id"), account.get("plan"), **account)
 
     def core_utilization(self, _from, to):
         """
@@ -79,7 +79,7 @@ class Client(object):
         Returns: a list of :class:`tdclient.models.Database`
         """
         databases = self.api.list_databases()
-        return [ models.Database(self, db_name, None, *args) for (db_name, args) in databases.items() ]
+        return [ models.Database(self, db_name, **kwargs) for (db_name, kwargs) in databases.items() ]
 
     def database(self, db_name):
         """
@@ -89,9 +89,9 @@ class Client(object):
         Returns: :class:`tdclient.models.Database`
         """
         databases = self.api.list_databases()
-        for (name, args) in databases.items():
+        for (name, kwargs) in databases.items():
             if name == db_name:
-                return models.Database(self, name, None, *args)
+                return models.Database(self, name, **kwargs)
         raise api.NotFoundError("Database '%s' does not exist" % (db_name))
 
     def create_log_table(self, db_name, table_name):

--- a/tdclient/database_api.py
+++ b/tdclient/database_api.py
@@ -26,11 +26,11 @@ class DatabaseAPI(object):
             result = {}
             for m in js["databases"]:
                 name = m.get("name")
-                count = m.get("count")
-                created_at = self._parsedate(self.get_or_else(m, "created_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ")
-                updated_at = self._parsedate(self.get_or_else(m, "updated_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ")
-                permission = m.get("permission")
-                result[name] = [count, created_at, updated_at, None, permission] # set None to org for API copatibility
+                m = dict(m)
+                m["created_at"] = self._parsedate(self.get_or_else(m, "created_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ")
+                m["updated_at"] = self._parsedate(self.get_or_else(m, "updated_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ")
+                m["org_name"] = None # set None to org for API copatibility
+                result[name] = m
             return result
 
     def delete_database(self, db):

--- a/tdclient/database_model.py
+++ b/tdclient/database_model.py
@@ -14,15 +14,15 @@ class Database(Model):
     PERMISSIONS = ["administrator", "full_access", "import_only", "query_only"]
     PERMISSION_LIST_TABLES = ["administrator", "full_access"]
 
-    def __init__(self, client, db_name, tables=None, count=None, created_at=None, updated_at=None, org_name=None, permission=None):
+    def __init__(self, client, db_name, **kwargs):
         super(Database, self).__init__(client)
         self._db_name = db_name
-        self._tables = tables
-        self._count = count
-        self._created_at = created_at
-        self._updated_at = updated_at
-        self._org_name = org_name
-        self._permission = permission
+        self._tables = kwargs.get("tables")
+        self._count = kwargs.get("count")
+        self._created_at = kwargs.get("created_at")
+        self._updated_at = kwargs.get("updated_at")
+        self._org_name = kwargs.get("org_name")
+        self._permission = kwargs.get("permission")
 
     @property
     def org_name(self):

--- a/tdclient/table_model.py
+++ b/tdclient/table_model.py
@@ -11,8 +11,7 @@ class Table(Model):
     """Database table on Treasure Data Service
     """
 
-    def __init__(self, client, db_name, table_name, type, schema, count, created_at=None, updated_at=None, estimated_storage_size=None,
-                 last_import=None, last_log_timestamp=None, expire_days=None, primary_key=None, primary_key_type=None):
+    def __init__(self, client, db_name, table_name, type, schema, count, **kwargs):
         super(Table, self).__init__(client)
         self.database = None
         self._db_name = db_name
@@ -20,14 +19,14 @@ class Table(Model):
         self._type = type
         self._schema = schema
         self._count = count
-        self._created_at = created_at
-        self._updated_at = updated_at
-        self._estimated_storage_size = estimated_storage_size
-        self._last_import = last_import
-        self._last_log_timestamp = last_log_timestamp
-        self._expire_days = expire_days
-        self._primary_key = primary_key
-        self._primary_key_type = primary_key_type
+        self._created_at = kwargs.get("created_at")
+        self._updated_at = kwargs.get("updated_at")
+        self._estimated_storage_size = kwargs.get("estimated_storage_size")
+        self._last_import = kwargs.get("last_import")
+        self._last_log_timestamp = kwargs.get("last_log_timestamp")
+        self._expire_days = kwargs.get("expire_days")
+        self._primary_key = kwargs.get("primary_key")
+        self._primary_key_type = kwargs.get("primary_key_type")
 
     @property
     def type(self):

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -45,7 +45,7 @@ def test_delete_database():
 def test_account():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
-    td._api.show_account = mock.MagicMock(return_value=(1, 0, 10, 0, 4, "2015-01-13 17:17:17 UTC"))
+    td._api.show_account = mock.MagicMock(return_value={"id":1, "plan":0, "storage_size":10, "guaranteed_cores":0, "maximum_cores":4, "created_at":"2015-01-13 17:17:17 UTC"})
     account = td.account()
     td.api.show_account.assert_called_with()
     assert account.account_id == 1
@@ -60,7 +60,7 @@ def test_core_utilization():
 def test_databases():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
-    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": [{"name":"nasdaq"}, {"name":"www_access"}]}))
+    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": {"nasdaq":{"name":"nasdaq"}, "www_access":{"name":"www_access"}}}))
     databases = td.databases()
     td.api.list_databases.assert_called_with()
     assert len(databases) == 1
@@ -68,7 +68,7 @@ def test_databases():
 def test_database_success():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
-    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": [{"name":"nasdaq"}, {"name":"www_access"}]}))
+    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": {"nasdaq":{"name":"nasdaq"}, "www_access":{"name":"www_access"}}}))
     database = td.database("sample_datasets")
     td.api.list_databases.assert_called_with()
     assert database.name == "sample_datasets"
@@ -76,7 +76,7 @@ def test_database_success():
 def test_database_failure():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
-    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": [{"name":"nasdaq"}, {"name":"www_access"}]}))
+    td._api.list_databases = mock.MagicMock(return_value=({"sample_datasets": {"nasdaq":{"name":"nasdaq"}, "www_access":{"name":"www_access"}}}))
     with pytest.raises(api.NotFoundError) as error:
         td.database("not_exist")
 

--- a/tdclient/test/database_api_test.py
+++ b/tdclient/test/database_api_test.py
@@ -31,7 +31,7 @@ def test_list_databases_success():
     td.get.assert_called_with("/v3/database/list")
     assert len(databases) == 3
     assert sorted(databases.keys()) == ["jma_weather", "sample_datasets", "test_db"]
-    assert sorted([ v[0] for v in databases.values() ]) == [15, 29545, 8812278]
+    assert sorted([ v.get("count") for v in databases.values() ]) == [15, 29545, 8812278]
 
 def test_list_databases_failure():
     td = api.API("APIKEY")

--- a/tdclient/user_model.py
+++ b/tdclient/user_model.py
@@ -9,7 +9,7 @@ class User(Model):
     """User on Treasure Data Service
     """
 
-    def __init__(self, client, name, org_name, role_names, email):
+    def __init__(self, client, name, org_name, role_names, email, **kwargs):
         super(User, self).__init__(client)
         self._name = name
         self._org_name = org_name


### PR DESCRIPTION
Using keyword arguments could be better than listing bunch of variables as parameters of `__init__`.