### PR TITLE
Pass string arguments to as in byte representation on Python 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 msgpack-python>=0.4,<0.5
 python-dateutil>=2.4.0,<2.5.0
+six
 urllib3>=1.10,<2.0


### PR DESCRIPTION
On Python 2.x, if we pass some unicode objects to urllib3, underlying `httplib` will raise `UnicodeDecodeError` like following.

```
Traceback (most recent call last):
  File "./x.py", line 13, in <module>
    cursor.execute(query)
  File "/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/cursor.py", line 45, in execute
    self._executed = self._api.query(query, **self._query_kwargs)
  File "/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/job_api.py", line 229, in query
    with self.post("/v3/job/issue/%s/%s" % (urlquote(str(type)), urlquote(str(db))), params) as res:
  File "/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/api.py", line 220, in post
    response = self.send_request("POST", url, fields=fields, body=body, headers=headers, decode_content=True, preload_content=False)
  File "/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/api.py", line 345, in send_request
    return self.http.request(method, url, fields=fields, **kwargs)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/site-packages/urllib3/request.py", line 70, in request
    **urlopen_kw)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/site-packages/urllib3/request.py", line 148, in request_encode_body
    return self.urlopen(method, url, **extra_kw)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/site-packages/urllib3/poolmanager.py", line 244, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/site-packages/urllib3/connectionpool.py", line 594, in urlopen
    chunked=chunked)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/site-packages/urllib3/connectionpool.py", line 361, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/httplib.py", line 1042, in request
    self._send_request(method, url, body, headers)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/httplib.py", line 1082, in _send_request
    self.endheaders(body)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/httplib.py", line 1038, in endheaders
    self._send_output(message_body)
  File "/home/yyuu/.pyenv/versions/2.7.13/lib/python2.7/httplib.py", line 880, in _send_output
    msg += message_body
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 92: ordinal not in range(128)
```

This is occurring because httplib will try to concatenate POST request body generated by [urllib3.filepost.encode_multipart_formdata](https://github.com/shazow/urllib3/blob/1.19.1/urllib3/filepost.py#L70) and request headers which may contain some unicode strings.

https://github.com/python/cpython/blob/803e6ca3cef2dfdd90298d8a11e57fc559317ea5/Lib/httplib.py#L867-L886

To deal with, I converted all request parameters to bytes representation on Python 2.x to avoid concatenation of bytes + unicode....