### PR TITLE
Allow specify request parameters in `str` instead of `unicode` on Python 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Version History
 
+## 0.8.0.dev0 (unreleased)
+
+* Fix unicode encoding issues on Python 2.x (#27, #28)
+
 ## 0.7.0 (2016-12-06)
 
 * Fix for tdclient tables data not populating
-* TableAPI.list_tables now returns a dictionary instead of a tuple
+* `TableAPI.list_tables` now returns a dictionary instead of a tuple
 
 ## 0.6.0 (2016-09-27)
 

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -342,17 +342,17 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
         return (url, _headers)
 
     def send_request(self, method, url, fields=None, body=None, headers=None, **kwargs):
-        def encode(xs, encoding):
-            if xs is None:
-                return None
-            else:
-                return dict([ (k.encode(encoding), v.encode(encoding)) for k, v in xs.items() ])
+        def as_bytes(s, encoding):
+            return s.encode(encoding) if isinstance(s, six.text_type) else s
+
         if six.PY2:
             # FIXME: Ugly workaround for `UnicodeDecodeError` from `httplib.HTTPConnection._send_output` when sending multi-byte payloads on Python 2.x (#27)
-            method = method.encode('utf-8')
-            url = url.encode('utf-8')
-            fields = encode(fields, 'utf-8')
-            headers = encode(headers, 'utf-8')
+            method = as_bytes(method, 'utf-8')
+            url = as_bytes(url, 'utf-8')
+            if fields is not None:
+                fields = dict([ (as_bytes(k, 'utf-8'), as_bytes(v, 'utf-8')) for k, v in fields.items() ])
+            if headers is not None:
+                headers = dict([ (as_bytes(k, 'utf-8'), as_bytes(v, 'utf-8')) for k, v in headers.items() ])
         if body is None:
             return self.http.request(method, url, fields=fields, headers=headers, **kwargs)
         else:


### PR DESCRIPTION
Without this, `UnicodeDecodeError` will occur if we specify request parameters as `str` instead of `unicode`. This should allow users to specify either `str` or `unicode`.


```
In [1]: job = td.query(u'sample_datasets', "SELECT 'こんにちは'", type='presto')
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-2-023ebc33ffee> in <module>()
----> 1 job = td.query(u'sample_datasets', "SELECT 'こんにちは'", type='presto')

/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/client.pyc in query(self, db_name, q, result_url, priority, retry_limit, type, **kwargs)
    217         if type not in ["hive", "pig", "impala", "presto"]:
    218             raise ValueError("The specified query type is not supported: %s" % (type))
--> 219         job_id = self.api.query(q, type=type, db=db_name, result_url=result_url, priority=priority, retry_limit=retry_limit, **kwargs)
    220         return models.Job(self, job_id, type, q)
    221

/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/job_api.pyc in query(self, q, type, db, result_url, priority, retry_limit, **kwargs)
    227         if retry_limit is not None:
    228             params["retry_limit"] = retry_limit
--> 229         with self.post("/v3/job/issue/%s/%s" % (urlquote(str(type)), urlquote(str(db))), params) as res:
    230             code, body = res.status, res.read()
    231             if code != 200:

/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/api.py in post(self, path, params, headers, **kwargs)
    219         while True:
    220             try:
--> 221                 response = self.send_request("POST", url, fields=fields, body=body, headers=headers, decode_content=True, preload_content=False)
    222                 # if the HTTP error code is 500 or higher and the user requested retrying
    223                 # on post request, attempt a retry

/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/api.py in send_request(self, method, url, fields, body, headers, **kwargs)
    352             method = method.encode('utf-8')
    353             url = url.encode('utf-8')
--> 354             fields = encode(fields, 'utf-8')
    355             headers = encode(headers, 'utf-8')
    356         if body is None:

/home/yyuu/work/repos/git/treasure-data/td-client-python/tdclient/api.py in encode(xs, encoding)
    347                 return None
    348             else:
--> 349                 return dict([ (k.encode(encoding), v.encode(encoding)) for k, v in xs.items() ])
    350         if six.PY2:
    351             # FIXME: Ugly workaround for `UnicodeDecodeError` from `httplib.HTTPConnection._send_output` when sending multi-byte payloads on Python 2.x (#27)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 8: ordinal not in range(128)

```