### PR TITLE
Fix for erroneous missing 'time' column warning

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -265,7 +265,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
                 stream = bytes_or_stream
             else:
                 stream = array(str("b"), bytes_or_stream.read())
-            
+
         else:
             # send request body as an `array.array` since `httplib` requires the request body to be a unicode string
             stream = array(str("b"), bytes_or_stream)
@@ -450,7 +450,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
             return reader(file_like, **kwargs)
 
     def _validate_record(self, record):
-        if "time" not in record:
+        if "time" not in record and b"time" not in record:
             warnings.warn("records should have \"time\" column to import records properly.", category=RuntimeWarning)
         return True
 

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -450,7 +450,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
             return reader(file_like, **kwargs)
 
     def _validate_record(self, record):
-        if "time" not in record and b"time" not in record:
+        if not any (k in record for k in ("time", b"time")):
             warnings.warn("records should have \"time\" column to import records properly.", category=RuntimeWarning)
         return True
 


### PR DESCRIPTION
As per https://pypi.python.org/pypi/msgpack-python,

"Currently, while msgpack-python supports new bin type, default
setting doesn't use it and decodes raw as bytes instead of
unicode (str in Python 3).