### PR TITLE
Ignore empty string in job's `start_at` and `end_at`

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -407,7 +407,13 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
 
     def get_or_else(self, hashmap, key, default_value=None):
         value = hashmap.get(key)
-        return default_value if value is None else value
+        if value is None:
+            return default_value
+        else:
+            if 0 < len(value.strip()):
+                return value
+            else:
+                return default_value
 
     def close(self):
         # urllib3 doesn't allow to close all connections immediately.

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -64,6 +64,8 @@ class JobAPI(object):
                     hive_result_schema = json.loads(m["hive_result_schema"])
                 else:
                     hive_result_schema = None
+                start_at = self.get_or_else(m, "start_at")
+                end_at = self.get_or_else(m, "end_at")
                 job = {
                     "job_id": m.get("job_id"),
                     "type": m.get("type", "?"),
@@ -71,8 +73,8 @@ class JobAPI(object):
                     "query": m.get("query"),
                     "status": m.get("status"),
                     "debug": m.get("debug"),
-                    "start_at": self._parsedate(self.get_or_else(m, "start_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ"),
-                    "end_at": self._parsedate(self.get_or_else(m, "end_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ"),
+                    "start_at": self._parsedate(start_at, "%Y-%m-%dT%H:%M:%SZ") if start_at else None,
+                    "end_at": self._parsedate(end_at, "%Y-%m-%dT%H:%M:%SZ") if end_at else None,
                     "cpu_time": m.get("cpu_time"),
                     "result_size": m.get("result_size"), # compressed result size in msgpack.gz format
                     "result": result,
@@ -107,6 +109,8 @@ class JobAPI(object):
                 hive_result_schema = json.loads(js["hive_result_schema"])
             else:
                 hive_result_schema = None
+            start_at = self.get_or_else(js, "start_at")
+            end_at = self.get_or_else(js, "end_at")
             job = {
                 "job_id": job_id,
                 "type": js.get("type", "?"),
@@ -114,8 +118,8 @@ class JobAPI(object):
                 "query": js.get("query"),
                 "status": js.get("status"),
                 "debug": js.get("debug"),
-                "start_at": self._parsedate(self.get_or_else(js, "start_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ"),
-                "end_at": self._parsedate(self.get_or_else(js, "end_at", "1970-01-01T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ"),
+                "start_at": self._parsedate(start_at, "%Y-%m-%dT%H:%M:%SZ") if start_at else None,
+                "end_at": self._parsedate(end_at, "%Y-%m-%dT%H:%M:%SZ") if end_at else None,
                 "cpu_time": js.get("cpu_time"),
                 "result_size": js.get("result_size"), # compressed result size in msgpack.gz format
                 "result": result,


### PR DESCRIPTION
This should fix #35 in favor of it. Note that `start_at` and `end_at` will be `None` if the API returned empty string as these values.