### PR TITLE
#39 Support missing parameters in JOB API

### DIFF
--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -242,6 +242,8 @@ class Client(object):
                 debug=d.get("debug"),
                 start_at=d.get("start_at"),
                 end_at=d.get("end_at"),
+                created_at=d.get("created_at"),
+                updated_at=d.get("updated_at"),
                 cpu_time=d.get("cpu_time"),
                 result_size=d.get("result_size"),
                 result=d.get("result"),
@@ -251,6 +253,10 @@ class Client(object):
                 retry_limit=d.get("retry_limit"),
                 org_name=d.get("org_name"),
                 database=d.get("database"),
+                num_records=d.get("num_records"),
+                user_name=d.get("user_name"),
+                linked_result_export_job_id=d.get("linked_result_export_job_id"),
+                result_export_target_job_id=d.get("result_export_target_job_id"),
             )
         return [ job(d) for d in results ]
 
@@ -273,6 +279,8 @@ class Client(object):
             debug=d.get("debug"),
             start_at=d.get("start_at"),
             end_at=d.get("end_at"),
+            created_at=d.get("created_at"),
+            updated_at=d.get("updated_at"),
             cpu_time=d.get("cpu_time"),
             result_size=d.get("result_size"),
             result=d.get("result"),
@@ -282,6 +290,10 @@ class Client(object):
             retry_limit=d.get("retry_limit"),
             org_name=d.get("org_name"),
             database=d.get("database"),
+            num_records=d.get("num_records"),
+            user_name=d.get("user_name"),
+            linked_result_export_job_id=d.get("linked_result_export_job_id"),
+            result_export_target_job_id=d.get("result_export_target_job_id"),
         )
 
     def job_status(self, job_id):

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -66,6 +66,8 @@ class JobAPI(object):
                     hive_result_schema = None
                 start_at = self.get_or_else(m, "start_at")
                 end_at = self.get_or_else(m, "end_at")
+                created_at = self.get_or_else(m, "created_at")
+                updated_at = self.get_or_else(m, "updated_at")
                 job = {
                     "job_id": m.get("job_id"),
                     "type": m.get("type", "?"),
@@ -75,6 +77,8 @@ class JobAPI(object):
                     "debug": m.get("debug"),
                     "start_at": self._parsedate(start_at, "%Y-%m-%dT%H:%M:%SZ") if start_at else None,
                     "end_at": self._parsedate(end_at, "%Y-%m-%dT%H:%M:%SZ") if end_at else None,
+                    "created_at": self._parsedate(created_at, "%Y-%m-%dT%H:%M:%SZ") if created_at else None,
+                    "updated_at": self._parsedate(updated_at, "%Y-%m-%dT%H:%M:%SZ") if updated_at else None,
                     "cpu_time": m.get("cpu_time"),
                     "result_size": m.get("result_size"), # compressed result size in msgpack.gz format
                     "result": result,
@@ -84,6 +88,10 @@ class JobAPI(object):
                     "retry_limit": m.get("retry_limit"),
                     "org_name": None,
                     "database": m.get("database"),
+                    "num_records": m.get("num_records"),
+                    "user_name": m.get("user_name"),
+                    "linked_result_export_job_id": m.get("linked_result_export_job_id"),
+                    "result_export_target_job_id": m.get("result_export_target_job_id"),
                 }
                 jobs.append(job)
             return jobs
@@ -111,6 +119,8 @@ class JobAPI(object):
                 hive_result_schema = None
             start_at = self.get_or_else(js, "start_at")
             end_at = self.get_or_else(js, "end_at")
+            created_at = self.get_or_else(js, "created_at")
+            updated_at = self.get_or_else(js, "updated_at")
             job = {
                 "job_id": job_id,
                 "type": js.get("type", "?"),
@@ -120,6 +130,8 @@ class JobAPI(object):
                 "debug": js.get("debug"),
                 "start_at": self._parsedate(start_at, "%Y-%m-%dT%H:%M:%SZ") if start_at else None,
                 "end_at": self._parsedate(end_at, "%Y-%m-%dT%H:%M:%SZ") if end_at else None,
+                "created_at": self._parsedate(created_at, "%Y-%m-%dT%H:%M:%SZ") if created_at else None,
+                "updated_at": self._parsedate(updated_at, "%Y-%m-%dT%H:%M:%SZ") if updated_at else None,
                 "cpu_time": js.get("cpu_time"),
                 "result_size": js.get("result_size"), # compressed result size in msgpack.gz format
                 "result": result,
@@ -129,6 +141,10 @@ class JobAPI(object):
                 "retry_limit": js.get("retry_limit"),
                 "org_name": None,
                 "database": js.get("database"),
+                "num_records": js.get("num_records"),
+                "user_name": js.get("user_name"),
+                "linked_result_export_job_id": js.get("linked_result_export_job_id"),
+                "result_export_target_job_id": js.get("result_export_target_job_id"),
             }
             return job
 

--- a/tdclient/job_model.py
+++ b/tdclient/job_model.py
@@ -82,6 +82,8 @@ class Job(Model):
         self._debug = data.get("debug")
         self._start_at = data.get("start_at")
         self._end_at = data.get("end_at")
+        self._created_at = data.get("created_at")
+        self._updated_at = data.get("updated_at")
         self._cpu_time = data.get("cpu_time")
         self._result = data.get("result")
         self._result_size = data.get("result_size")
@@ -91,6 +93,10 @@ class Job(Model):
         self._retry_limit = data.get("retry_limit")
         self._org_name = data.get("org_name")
         self._database = data.get("database")
+        self._num_records = data.get("num_records")
+        self._user_name = data.get("user_name")
+        self._linked_result_export_job_id = data.get("linked_result_export_job_id")
+        self._result_export_target_job_id = data.get("result_export_target_job_id")
 
     def update(self):
         """Update all fields of the job
@@ -135,6 +141,13 @@ class Job(Model):
         Returns: the length of job result
         """
         return self._result_size
+    
+    @property
+    def num_records(self):
+        """
+        Returns: the number of records of job result
+        """
+        return self._num_records
 
     @property
     def result_url(self):
@@ -176,11 +189,32 @@ class Job(Model):
         return self._org_name
 
     @property
+    def user_name(self):
+        """
+        Returns: executing user name
+        """
+        return self._user_name
+
+    @property
     def database(self):
         """
         Returns: a string represents the name of a database that job is running on
         """
         return self._database
+    
+    @property
+    def linked_result_export_job_id(self):
+        """
+        TODO: add docstring
+        """
+        return self._linked_result_export_job_id
+
+    @property
+    def result_export_target_job_id(self):
+        """
+        TODO: add docstring
+        """
+        return self._result_export_target_job_id
 
     @property
     def debug(self):

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -80,7 +80,10 @@ def test_show_job_success():
             "type": "presto",
             "updated_at": "2015-02-09 11:44:28 UTC",
             "url": "http://console.example.com/jobs/12345",
-            "user_name": "nobody@example.com"
+            "user_name": "nobody@example.com",
+            "linked_result_export_job_id": null,
+            "result_export_target_job_id": null,
+            "num_records": 4
         }
     """
     td.get = mock.MagicMock(return_value=make_response(200, body))

--- a/tdclient/test/job_model_test.py
+++ b/tdclient/test/job_model_test.py
@@ -304,6 +304,8 @@ def test_job_update_status():
         "debug": None,
         "start_at": datetime.datetime(2015, 2, 10, 0, 2, 14, tzinfo=dateutil.tz.tzutc()),
         "end_at": datetime.datetime(2015, 2, 10, 0, 2, 27, tzinfo=dateutil.tz.tzutc()),
+        "created_at": datetime.datetime(2015, 2, 10, 0, 2, 13, tzinfo=dateutil.tz.tzutc()),
+        "updated_at": datetime.datetime(2015, 2, 10, 0, 2, 15, tzinfo=dateutil.tz.tzutc()),
         "cpu_time": None,
         "result_size": 22,
         "result": None,
@@ -313,6 +315,10 @@ def test_job_update_status():
         "retry_limit": 0,
         "org_name": None,
         "database": "sample_datasets",
+        "num_records": 1,
+        "user_name": "Treasure Data",
+        "linked_result_export_job_id": None,
+        "result_export_target_job_id": None,
     })
     job = models.Job(client, "67890", "hive", "SELECT COUNT(1) FROM nasdaq")
     job.finished = mock.MagicMock(return_value=False)


### PR DESCRIPTION
Support the following parameters for list jobs and show job;

- created_at
- updated_at
- num_records
- user_name
- linked_result_export_job_id
- result_export_target_job_id

Could you review this?