### PR TITLE
Tweaking library dependency versions & deprecate 2.6 completely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msgpack-python>=0.4,<0.5
-python-dateutil>=2.4.0,<2.5.0
+msgpack-python==0.5.6
+python-dateutil==2.7.3
 six
-urllib3>=1.10,<2.0
+urllib3==1.22

--- a/setup.py
+++ b/setup.py
@@ -29,16 +29,6 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-install_requires = []
-with open("requirements.txt") as fp:
-    for s in fp:
-        install_requires.append(s.strip())
-
-tests_require = []
-with open("test-requirements.txt") as fp:
-    for s in fp:
-        tests_require.append(s.strip())
-
 setup(
     name="td-client",
     version=version,
@@ -47,8 +37,19 @@ setup(
     author="Treasure Data, Inc.",
     author_email="support@treasure-data.com",
     url="http://treasuredata.com/",
-    install_requires=install_requires,
-    tests_require=tests_require,
+    install_requires=[
+        "msgpack-python",
+        "python-dateutil",
+        "six",
+        "urllib3",
+    ],
+    test_requires=[
+        "coveralls",
+        "mock",
+        "pytest",
+        "pytest-cov",
+        "tox",
+    ],
     packages=find_packages(),
     cmdclass = {"test": PyTest},
     license="Apache Software License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35,pypy
 
 [testenv]
 deps=-r{toxinidir}/test-requirements.txt
 commands=py.test
-
-[testenv:py26]
-basepython=python2.6
 
 [testenv:py27]
 basepython=python2.7


### PR DESCRIPTION
Management of dependencies of overall application is a responsibility of application itself. This change is to let application to manage their dependencies at their own risk.