### PR TITLE
Return `None` or `[]` on `fetchone` and `fetchall` with empty result set of query instead of raising exception (fixes #43)

### DIFF
--- a/tdclient/cursor.py
+++ b/tdclient/cursor.py
@@ -82,15 +82,22 @@ class Cursor(object):
         return [ (column[0], None, None, None, None, None, None) for column in result_schema ]
 
     def fetchone(self):
+        """
+        Fetch the next row of a query result set, returning a single sequence, or `None` when no more data is available.
+        """
         self._check_executed()
         if self._rownumber < self._rowcount:
             row = self._rows[self._rownumber]
             self._rownumber += 1
             return row
         else:
-            raise errors.InternalError("index out of bound (%d out of %d)" % (self._rownumber, self._rowcount))
+            return None
 
     def fetchmany(self, size=None):
+        """
+        Fetch the next set of rows of a query result, returning a sequence of sequences (e.g. a list of tuples).
+        An empty sequence is returned when no more rows are available.
+        """
         if size is None:
             return self.fetchall()
         else:
@@ -103,13 +110,17 @@ class Cursor(object):
                 raise errors.InternalError("index out of bound (%d out of %d)" % (self._rownumber, self._rowcount))
 
     def fetchall(self):
+        """
+        Fetch all (remaining) rows of a query result, returning them as a sequence of sequences (e.g. a list of tuples).
+        Note that the cursor's arraysize attribute can affect the performance of this operation.
+        """
         self._check_executed()
         if self._rownumber < self._rowcount:
             rows = self._rows[self._rownumber:]
             self._rownumber = self._rowcount
             return rows
         else:
-            raise errors.InternalError("row index out of bound (%d out of %d)" % (self._rownumber, self._rowcount))
+            return []
 
     def nextset(self):
         raise errors.NotSupportedError

--- a/tdclient/test/cursor_test.py
+++ b/tdclient/test/cursor_test.py
@@ -133,8 +133,7 @@ def test_fetchone():
     assert td.fetchone() == ["foo", 1]
     assert td.fetchone() == ["bar", 1]
     assert td.fetchone() == ["baz", 2]
-    with pytest.raises(errors.InternalError) as error:
-        td.fetchone()
+    assert td.fetchone() == None
 
 def test_fetchmany():
     td = cursor.Cursor(mock.MagicMock())
@@ -144,8 +143,9 @@ def test_fetchmany():
     td._rowcount = len(td._rows)
     assert td.fetchmany(2) == [["foo", 1], ["bar", 1]]
     assert td.fetchmany() == [["baz", 2]]
+    assert td.fetchmany() == []
     with pytest.raises(errors.InternalError) as error:
-        td.fetchmany()
+        td.fetchmany(1)
 
 def test_fetchall():
     td = cursor.Cursor(mock.MagicMock())
@@ -154,8 +154,7 @@ def test_fetchall():
     td._rownumber = 0
     td._rowcount = len(td._rows)
     assert td.fetchall() == [["foo", 1], ["bar", 1], ["baz", 2]]
-    with pytest.raises(errors.InternalError) as error:
-        td.fetchall()
+    assert td.fetchall() == []
 
 def test_show_job():
     td = cursor.Cursor(mock.MagicMock())


### PR DESCRIPTION
Continued from #43.

So far [DBAPI2](https://www.python.org/dev/peps/pep-0249/) interface of td-client-python was implemented to raise some exception for empty result set of a query because I interpreted that "previous call to `.execute*()` did not produce any result set or no call was issued yet" was requesting so.

> fetchone()
> ( ... )
> An Error (or subclass) exception is raised if the previous call to .execute*() did not produce any result set or no call was issued yet.
https://www.python.org/dev/peps/pep-0249/#fetchone

However, it looks like somehow I overlooked the first sentence of the description; it should return `None` when no more data is available.

> Fetch the next row of a query result set, returning a single sequence, or None when no more data is available. [6]
https://www.python.org/dev/peps/pep-0249/#fetchone

Just in case, I checked the documentations of other DBAPI2 implementations, and have confirmed that other implementations also return empty list on empty result set. This changes some behavior of the library; however stop raising exception won't break anything, I believe.

> fetchall()
> Fetches all (remaining) rows of a query result, returning a list. Note that the cursor’s arraysize attribute can affect the performance of this operation. An empty list is returned when no rows are available.
https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.fetchall

> fetchall()
> Fetch all (remaining) rows of a query result, returning them as a list of tuples. An empty list is returned if there is no more record to fetch.
http://initd.org/psycopg/docs/cursor.html?highlight=fetchall#cursor.fetchall