### PR TITLE
Update api.py

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -407,7 +407,7 @@ class API(AccessControlAPI, AccountAPI, BulkImportAPI, ConnectorAPI, DatabaseAPI
 
     def get_or_else(self, hashmap, key, default_value=None):
         value = hashmap.get(key)
-        return default_value if value is None else value
+        return default_value if value is None else (value if value.strip() else default_value)
 
     def close(self):
         # urllib3 doesn't allow to close all connections immediately.


### PR DESCRIPTION
it will get empty string('') at line 75 and line 118 of job_api.py,
becasue "end_at" is empty string in still running job.

Fixed:
return default_value if value is None else value
↓
return default_value if value is None else (value if value.strip() else default_value)