### PR TITLE
Set urllib3 minimum version as v1.24.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 msgpack==0.6.1
 python-dateutil==2.7.3
 six
-urllib3==1.22
+urllib3>=1.24.1


### PR DESCRIPTION
Since urllib3 v1.22 has a vulnerability, this PR will fix the issue.
https://github.com/treasure-data/td-client-python/network/alert/requirements.txt/urllib3/open