### PR TITLE
Update urllib3>=1.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 msgpack==0.6.1
 python-dateutil==2.7.3
 six
-urllib3==1.22
+urllib3>=1.23


### PR DESCRIPTION
CVE-2018-20060 More information
high severity
Vulnerable versions: < 1.23
Patched version: 1.23
urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.