### PR TITLE
Implement TableAPI.tail method

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -556,8 +556,6 @@ class API(
             js = json.loads(body.decode("utf-8"))
         except ValueError as error:
             raise APIError("Unexpected API response: %s: %s" % (error, repr(body)))
-        if isinstance(js, list):
-            return js
         js = dict(js)
         if 0 < [k in js for k in required].count(False):
             missing = [k for k in required if k not in js]

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -556,6 +556,8 @@ class API(
             js = json.loads(body.decode("utf-8"))
         except ValueError as error:
             raise APIError("Unexpected API response: %s: %s" % (error, repr(body)))
+        if isinstance(js, list):
+            return js
         js = dict(js)
         if 0 < [k in js for k in required].count(False):
             missing = [k for k in required if k not in js]

--- a/tdclient/table_api.py
+++ b/tdclient/table_api.py
@@ -132,3 +132,30 @@ class TableAPI:
             js = self.checked_json(body, [])
             t = js.get("type", "?")
             return t
+
+    def tail(self, db, table, count, to=None, _from=None, block=None):
+        """Get the contents of the table in reverse order based on the registered time
+        (last data first).
+
+        Args:
+            db (str): Target database name.
+            table (str): Target table name.
+            count (int): Number for record to show up from the end.
+            to: Deprecated parameter.
+            _from: Deprecated parameter.
+            block: Deprecated parameter.
+
+        Returns:
+            [dict]: Contents of the table.
+        """
+        params = {"count": count}
+        with self.get(
+            "/v3/table/tail/%s/%s" % (urlquote(str(db)), urlquote(str(table))),
+            params
+        ) as res:
+            code, body = res.status, res.read()
+            if code != 200:
+                self.raise_error("Tail table failed", res, body)
+
+            js = self.checked_json(body, [])
+            return js


### PR DESCRIPTION
While `API` class assumes `tail` function, there is no implementation for `TableAPI` class. This PR introduces the `TableAPI.tail` method, to enable the capability.

Before:
```py
In [36]: with tdclient.Client() as td:
    ...:     td.tail("aki", "iris", 10)
    ...:
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-36-e94fce9ef607> in <module>
      1 with tdclient.Client() as td:
----> 2     td.tail("aki", "iris", 10)
      3

~/src/td-client-python/tdclient/client.py in tail(self, db_name, table_name, count, to, _from, block)
    190         TODO: add docstring
    191         """
--> 192         return self.api.tail(db_name, table_name, count, to, _from, block)
    193
    194     def query(

AttributeError: 'API' object has no attribute 'tail'
```

After:
```py
In [5]: td.tail('aki', 'iris', 5)
Out[5]:
[{'species': 'setosa',
  'sepal_width': '3.9',
  'petal_width': '0.4',
  'petal_length': '1.7',
  'time': 1548826482,
  'sepal_length': '5.4'},
 {'species': 'setosa',
  'sepal_width': '3.4',
  'petal_width': '0.3',
  'petal_length': '1.4',
  'time': 1548826482,
  'sepal_length': '4.6'},
 {'species': 'setosa',
  'sepal_width': '3.4',
  'petal_width': '0.2',
  'petal_length': '1.5',
  'time': 1548826482,
  'sepal_length': '5.0'},
 {'species': 'setosa',
  'sepal_width': '2.9',
  'petal_width': '0.2',
  'petal_length': '1.4',
  'time': 1548826482,
  'sepal_length': '4.4'},
 {'species': 'setosa',
  'sepal_width': '3.1',
  'petal_width': '0.1',
  'petal_length': '1.5',
  'time': 1548826482,
  'sepal_length': '4.9'}]
```