### PR TITLE
Cleanup non-public API call, Py2 dependent codes, and Deprecated codes

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -119,37 +119,6 @@ class API(
             pool_options["ca_certs"] = certs
             pool_options["cert_reqs"] = ssl.CERT_REQUIRED
 
-        if (
-            "connect_timeout" in pool_options
-            or "read_timeout" in pool_options
-            or "send_timeout" in pool_options
-        ):
-            if "connect_timeout" in pool_options:
-                warnings.warn(
-                    "connect_timeout will be removed from future release. Please use timeout instead.",
-                    category=DeprecationWarning,
-                )
-                connect_timeout = pool_options.pop("connect_timeout")
-            else:
-                connect_timeout = 0
-            if "read_timeout" in pool_options:
-                warnings.warn(
-                    "read_timeout will be removed from future release. Please use timeout instead.",
-                    category=DeprecationWarning,
-                )
-                read_timeout = pool_options.pop("read_timeout")
-            else:
-                read_timeout = 0
-            if "send_timeout" in pool_options:
-                warnings.warn(
-                    "send_timeout will be removed from future release. Please use timeout instead.",
-                    category=DeprecationWarning,
-                )
-                send_timeout = pool_options.pop("send_timeout")
-            else:
-                send_timeout = 0
-            pool_options["timeout"] = max(connect_timeout, read_timeout, send_timeout)
-
         if "timeout" not in pool_options:
             pool_options["timeout"] = 60
 
@@ -563,24 +532,6 @@ class API(
                 "Unexpected API response: %s: %s" % (repr(missing), repr(body))
             )
         return js
-
-    def sleep(self, secs):
-        warnings.warn(
-            "sleep(secs) will be removed from future release. Please use time.sleep(secs)",
-            category=DeprecationWarning,
-        )
-        time.sleep(secs)
-
-    def parsedate(self, s):
-        warnings.warn(
-            "parsedate(secs) will be removed from future release. Please use datetime.strptime(date_string, fmt) or other.",
-            category=DeprecationWarning,
-        )
-        try:
-            return self._parsedate(s, None)
-        except ValueError:
-            log.warning("Failed to parse date string: %s" % (s,))
-            return None
 
     def _parsedate(self, s, fmt):
         # TODO: parse datetime with using format string

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -538,7 +538,7 @@ class API(
 
     def raise_error(self, msg, res, body):
         status_code = res.status
-        s = body.decode("utf-8")
+        s = body if isinstance(body, str) else body.decode("utf-8")
         if status_code == 404:
             raise errors.NotFoundError("%s: %s" % (msg, s))
         elif status_code == 409:

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -666,19 +666,11 @@ class API(
     def _read_csv_file(
         self, file_like, dialect=csv.excel, columns=None, encoding="utf-8", **kwargs
     ):
-        try:
-            unicode
-            py2k = True
-        except NameError:
-            py2k = False
-        # `csv` module bundled with py2k doesn't support `unicode` :(
-        # https://docs.python.org/2/library/csv.html#examples
         def getreader(file_like):
             for s in codecs.getreader(encoding)(file_like):
-                yield s.encode(encoding) if py2k else s
+                yield s
 
         def value(s):
-            s = s.decode(encoding) if py2k else s
             try:
                 return int(s)
             except (OverflowError, ValueError):

--- a/tdclient/bulk_import_api.py
+++ b/tdclient/bulk_import_api.py
@@ -277,19 +277,6 @@ class BulkImportAPI:
             body = io.BytesIO(res.read())
             decompressor = gzip.GzipFile(fileobj=body)
 
-            content_type = res.getheader(
-                "content-type", "application/x-msgpack; charset=utf-8"
-            )
-            type_params = dict(
-                [
-                    p.strip().split("=", 2)
-                    for p in content_type.split(";")
-                    if 0 < p.find("=")
-                ]
-            )
-
-            unpacker = msgpack.Unpacker(
-                decompressor, encoding=str(type_params.get("charset", "utf-8"))
-            )
+            unpacker = msgpack.Unpacker(decompressor, raw=False)
             for row in unpacker:
                 yield row

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -90,24 +90,6 @@ class Client:
         """
         return self.api.create_log_table(db_name, table_name)
 
-    def create_item_table(self, db_name, table_name, primary_key, primary_key_type):
-        """
-        Args:
-            db_name (str): name of a database
-            table_name (str): name of a table to create
-            primary_key (str): name of primary key column
-            primary_key_type (str): type of primary key column
-
-        Returns: `True` if success
-        """
-        warnings.warn(
-            "item tables have been deprecated. will be deleted from future releases.",
-            category=DeprecationWarning,
-        )
-        return self.api.create_item_table(
-            db_name, table_name, primary_key, primary_key_type
-        )
-
     def swap_table(self, db_name, table_name1, table_name2):
         """
         Args:

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -842,17 +842,6 @@ class Client:
         """
         return self.api.remove_user(name)
 
-    def change_email(self, name, email):
-        """
-        TODO: remove
-        Args:
-            name (str): name of the user
-            email (str) new e-mail address
-
-        Returns: `True` if success
-        """
-        return self.api.change_email(name, email)
-
     def list_apikeys(self, name):
         """
         Args:
@@ -880,60 +869,6 @@ class Client:
         Returns: `True` if success
         """
         return self.api.remove_apikey(name, apikey)
-
-    def change_password(self, name, password):
-        """
-        Args:
-            name (str): name of the user
-            password (str): new password
-
-        Returns: `True` if success
-        """
-        return self.api.change_password(name, password)
-
-    def change_my_password(self, old_password, password):
-        """
-        TODO: remove
-        Args:
-            old_password (str): old password
-            password (str): new password
-
-        Returns: `True` if success
-        """
-        return self.api.change_my_password(old_password, password)
-
-    def access_controls(self):
-        """
-        Returns: a list of :class:`tdclient.models.AccessControl`
-        """
-        results = self.api.list_access_controls()
-
-        def access_control(m):
-            subject, action, scope, grant_option = m
-            return models.AccessControl(self, subject, action, scope, grant_option)
-
-        return [access_control(m) for m in results]
-
-    def grant_access_control(self, subject, action, scope, grant_option):
-        """
-        TODO: remove
-        => True
-        """
-        return self.api.grant_access_control(subject, action, scope, grant_option)
-
-    def revoke_access_control(self, subject, action, scope):
-        """
-        TODO: remove
-        => True
-        """
-        return self.api.revoke_access_control(subject, action, scope)
-
-    def test_access_control(self, user, action, scope):
-        """
-        TODO: remove
-        => True
-        """
-        return self.api.test_access_control(user, action, scope)
 
     def close(self):
         """Close opened API connections.

--- a/tdclient/database_model.py
+++ b/tdclient/database_model.py
@@ -71,19 +71,6 @@ class Database(Model):
         """
         return self._client.create_log_table(self._db_name, name)
 
-    def create_item_table(self, name):
-        """
-        Args:
-            name (str): name of new item table
-
-        Returns: :class:`tdclient.model.Table`
-        """
-        warnings.warn(
-            "item tables have been deprecated. will be deleted from future releases.",
-            category=DeprecationWarning,
-        )
-        return self._client.create_item_table(self._db_name, name)
-
     def table(self, table_name):
         """
         Args:

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -234,7 +234,7 @@ class JobAPI:
             if code != 200:
                 self.raise_error("Get job result failed", res, "")
             if format == "msgpack":
-                unpacker = msgpack.Unpacker(res, encoding=str("utf-8"))
+                unpacker = msgpack.Unpacker(res, raw=False)
                 for row in unpacker:
                     yield row
             elif format == "json":

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -258,24 +258,6 @@ class JobAPI:
             former_status = js.get("former_status")
             return former_status
 
-    def hive_query(self, q, **kwargs):
-        warnings.warn(
-            'hive_query(q, ...) will be removed from future release. Please use query(q, type="hive", ...)',
-            category=DeprecationWarning,
-        )
-        kwargs = dict(kwargs)
-        kwargs["type"] = "hive"
-        return self.query(q, **kwargs)
-
-    def pig_query(self, q, **kwargs):
-        warnings.warn(
-            'pig_query(q, ...) will be removed from future release. Please use query(q, type="pig", ...)',
-            category=DeprecationWarning,
-        )
-        kwargs = dict(kwargs)
-        kwargs["type"] = "pig"
-        return self.query(q, **kwargs)
-
     def query(
         self,
         q,

--- a/tdclient/table_api.py
+++ b/tdclient/table_api.py
@@ -86,18 +86,6 @@ class TableAPI:
         """
         return self._create_table(db, table, "log")
 
-    def create_item_table(self, db, table, primary_key, primary_key_type):
-        """[Deprecated] Create a new table for item.
-
-        => True
-        """
-        warnings.warn(
-            "item tables have been deprecated. will be deleted from future releases.",
-            category=DeprecationWarning,
-        )
-        params = {"primary_key": primary_key, "primary_key_type": primary_key_type}
-        return self._create_table(db, table, "item", params)
-
     def _create_table(self, db, table, type, params=None):
         params = {} if params is None else params
         with self.post(

--- a/tdclient/test/api_test.py
+++ b/tdclient/test/api_test.py
@@ -158,14 +158,6 @@ def test_timeout():
         assert kwargs["timeout"] == 12345
 
 
-def test_connect_timeout():
-    with mock.patch("tdclient.api.urllib3") as urllib3:
-        td = api.API("apikey", connect_timeout=1, read_timeout=2, send_timeout=4)
-        assert urllib3.PoolManager.called
-        args, kwargs = urllib3.PoolManager.call_args
-        assert kwargs["timeout"] == 4
-
-
 def test_get_success():
     td = api.API("APIKEY")
     with mock.patch("time.sleep") as t_sleep:
@@ -717,29 +709,6 @@ def test_checked_json_field_error():
     td = api.API("APIKEY")
     with pytest.raises(api.APIError) as error:
         td.checked_json(b"{}", ["foo"])
-
-
-def test_sleep_compat():
-    with mock.patch("tdclient.api.time") as time:
-        td = api.API("apikey")
-        td.sleep(600)
-        assert time.sleep.called
-        args, kwargs = time.sleep.call_args
-        assert args == (600,)
-
-
-def test_parsedate_compat():
-    td = api.API("APIKEY")
-    dt = td.parsedate("2013-11-01 16:48:41 -0700")  # ???
-    assert dt.year == 2013
-    assert dt.month == 11
-    assert dt.day == 1
-    assert dt.hour == 16
-    assert dt.minute == 48
-    assert dt.second == 41
-    offset = dt.utcoffset()
-    total_seconds = (offset.seconds + offset.days * 24 * 3600) * 10 ** 6 / 10 ** 6
-    assert total_seconds == -7 * 3600
 
 
 def test_parsedate1():

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -576,14 +576,6 @@ def test_remove_user():
     td.api.remove_user("name")
 
 
-def test_change_email():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.change_email = mock.MagicMock()
-    td.change_email("user", "email")
-    td.api.change_email("user", "email")
-
-
 def test_list_apikeys():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()
@@ -606,52 +598,3 @@ def test_remove_apikey():
     td._api.remove_apikey = mock.MagicMock()
     td.remove_apikey("user", "apikey")
     td.api.remove_apikey("user", "apikey")
-
-
-def test_change_password():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.change_password = mock.MagicMock()
-    td.change_password("user", "password")
-    td.api.change_password("user", "password")
-
-
-def test_change_my_password():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.change_my_password = mock.MagicMock()
-    td.change_my_password("old_password", "password")
-    td.api.change_my_password("old_password", "password")
-
-
-def test_access_controls():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.list_access_controls = mock.MagicMock(return_value=[])
-    access_controls = td.access_controls()
-    td.api.list_access_controls.assert_called_with()
-    assert len(access_controls) == 0
-
-
-def test_grant_access_control():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.grant_access_control = mock.MagicMock()
-    td.grant_access_control("subject", "action", "scope", "grant_option")
-    td.api.grant_access_control("subject", "action", "scope", "grant_option")
-
-
-def test_revoke_access_control():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.revoke_access_control = mock.MagicMock()
-    td.revoke_access_control("subject", "action", "scope")
-    td.api.revoke_access_control("subject", "action", "scope")
-
-
-def test_test_access_control():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.test_access_control = mock.MagicMock()
-    td.test_access_control("subject", "action", "scope")
-    td.api.test_access_control("subject", "action", "scope")

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api, client

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -103,16 +103,6 @@ def test_create_log_table():
     td.api.create_log_table.assert_called_with("db_name", "table_name")
 
 
-def test_create_item_table():
-    td = client.Client("APIKEY")
-    td._api = mock.MagicMock()
-    td._api.create_item_table = mock.MagicMock()
-    td.create_item_table("db_name", "table_name", "primary_key", "primary_key_type")
-    td.api.create_item_table.assert_called_with(
-        "db_name", "table_name", "primary_key", "primary_key_type"
-    )
-
-
 def test_swap_table():
     td = client.Client("APIKEY")
     td._api = mock.MagicMock()

--- a/tdclient/test/connection_test.py
+++ b/tdclient/test/connection_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import connection, cursor, errors

--- a/tdclient/test/cursor_test.py
+++ b/tdclient/test/cursor_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import cursor, errors

--- a/tdclient/test/database_api_test.py
+++ b/tdclient/test/database_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/export_api_test.py
+++ b/tdclient/test/export_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -196,64 +196,6 @@ def test_kill_success():
     td.post.assert_called_with("/v3/job/kill/12345")
 
 
-def test_hive_query_success():
-    td = api.API("APIKEY")
-    body = b"""
-        {
-            "job": "12345",
-            "database": "sample_datasets",
-            "job_id": "12345"
-        }
-    """
-    td.post = mock.MagicMock(return_value=make_response(200, body))
-    job_id = td.hive_query("SELECT COUNT(1) FROM nasdaq", db="sample_datasets")
-    td.post.assert_called_with(
-        "/v3/job/issue/hive/sample_datasets", {"query": "SELECT COUNT(1) FROM nasdaq"}
-    )
-    assert job_id == "12345"
-
-
-def test_pig_query_success():
-    td = api.API("APIKEY")
-    body = b"""
-        {
-            "job": "12345",
-            "database": "sample_datasets",
-            "job_id": "12345"
-        }
-    """
-    td.post = mock.MagicMock(return_value=make_response(200, body))
-    job_id = td.pig_query(
-        "A=LOAD 'nasdaq';B=GROUP A ALL;C=FOREACH B GENERATE COUNT(A);",
-        db="sample_datasets",
-    )
-    td.post.assert_called_with(
-        "/v3/job/issue/pig/sample_datasets",
-        {"query": "A=LOAD 'nasdaq';B=GROUP A ALL;C=FOREACH B GENERATE COUNT(A);"},
-    )
-    assert job_id == "12345"
-
-
-def test_presto_query_success():
-    td = api.API("APIKEY")
-    body = b"""
-        {
-            "job": "12345",
-            "database": "sample_datasets",
-            "job_id": "12345"
-        }
-    """
-    td.post = mock.MagicMock(return_value=make_response(200, body))
-    job_id = td.query(
-        "SELECT COUNT(1) FROM nasdaq", db="sample_datasets", type="presto", priority=0
-    )
-    td.post.assert_called_with(
-        "/v3/job/issue/presto/sample_datasets",
-        {"query": "SELECT COUNT(1) FROM nasdaq", "priority": 0},
-    )
-    assert job_id == "12345"
-
-
 def test_query_success():
     td = api.API("APIKEY")
     body = b"""

--- a/tdclient/test/partial_delete_api_test.py
+++ b/tdclient/test/partial_delete_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/pseudo_certifi_test.py
+++ b/tdclient/test/pseudo_certifi_test.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import functools
+from unittest import mock
 
 from tdclient import pseudo_certifi as certifi
 

--- a/tdclient/test/result_api_test.py
+++ b/tdclient/test/result_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/result_model_test.py
+++ b/tdclient/test/result_model_test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from tdclient import models
 from tdclient.test.test_helper import *

--- a/tdclient/test/schedule_api_test.py
+++ b/tdclient/test/schedule_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/schedule_model_test.py
+++ b/tdclient/test/schedule_model_test.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import time
+from unittest import mock
 
 from tdclient import models
 from tdclient.test.test_helper import *

--- a/tdclient/test/server_status_api_test.py
+++ b/tdclient/test/server_status_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/table_api_test.py
+++ b/tdclient/test/table_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/table_api_test.py
+++ b/tdclient/test/table_api_test.py
@@ -46,16 +46,6 @@ def test_create_log_table_success():
     td.post.assert_called_with("/v3/table/create/sample_datasets/nasdaq/log", {})
 
 
-def test_create_item_table_success():
-    td = api.API("APIKEY")
-    td.post = mock.MagicMock(return_value=make_response(200, b""))
-    td.create_item_table("sample_datasets", "nasdaq", "id", "INT")
-    td.post.assert_called_with(
-        "/v3/table/create/sample_datasets/nasdaq/item",
-        {"primary_key": "id", "primary_key_type": "INT"},
-    )
-
-
 def test_swap_table_success():
     td = api.API("APIKEY")
     td.post = mock.MagicMock(return_value=make_response(200, b""))

--- a/tdclient/test/table_model_test.py
+++ b/tdclient/test/table_model_test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from tdclient import models
 from tdclient.test.test_helper import *

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -73,7 +73,7 @@ def msgpackb(lis):
 
 def msgunpackb(bytes):
     """bytes -> list"""
-    unpacker = msgpack.Unpacker(io.BytesIO(bytes), encoding=str("utf-8"))
+    unpacker = msgpack.Unpacker(io.BytesIO(bytes), raw=False)
     return list(unpacker)
 
 

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -8,15 +8,11 @@ import io
 import json
 import os
 import zlib
+from unittest import mock
 
 import msgpack
 
 from tdclient.api import normalized_msgpack
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 def unset_environ():

--- a/tdclient/test/user_api_test.py
+++ b/tdclient/test/user_api_test.py
@@ -73,15 +73,6 @@ def test_remove_user_success():
     td.post.assert_called_with("/v3/user/remove/user")
 
 
-def test_change_email_success():
-    td = api.API("APIKEY")
-    td.post = mock.MagicMock(return_value=make_response(200, b""))
-    apikey = td.change_email("user", "email@example.com")
-    td.post.assert_called_with(
-        "/v3/user/email/change/user", {"email": "email@example.com"}
-    )
-
-
 def test_list_apikeys_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump
@@ -107,19 +98,3 @@ def test_remove_apikey_success():
     td.post = mock.MagicMock(return_value=make_response(200, b""))
     apikeys = td.remove_apikey("foo", "bar")
     td.post.assert_called_with("/v3/user/apikey/remove/foo", {"apikey": "bar"})
-
-
-def test_change_password_success():
-    td = api.API("APIKEY")
-    td.post = mock.MagicMock(return_value=make_response(200, b""))
-    apikeys = td.change_password("foo", "bar")
-    td.post.assert_called_with("/v3/user/password/change/foo", {"password": "bar"})
-
-
-def test_change_my_password_success():
-    td = api.API("APIKEY")
-    td.post = mock.MagicMock(return_value=make_response(200, b""))
-    apikeys = td.change_my_password("foo", "bar")
-    td.post.assert_called_with(
-        "/v3/user/password/change", {"old_password": "foo", "password": "bar"}
-    )

--- a/tdclient/test/user_api_test.py
+++ b/tdclient/test/user_api_test.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 import pytest
 
 from tdclient import api

--- a/tdclient/test/user_model_test.py
+++ b/tdclient/test/user_model_test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from tdclient import models
 from tdclient.test.test_helper import *

--- a/tdclient/user_api.py
+++ b/tdclient/user_api.py
@@ -84,20 +84,6 @@ class UserAPI:
                 self.raise_error("Removing user failed", res, body)
             return True
 
-    def change_email(self, name, email):
-        """
-        TODO: remove
-        => True
-        """
-        params = {"email": email}
-        with self.post(
-            "/v3/user/email/change/%s" % (urlquote(str(name))), params
-        ) as res:
-            code, body = res.status, res.read()
-            if code != 200:
-                self.raise_error("Changing email failed", res, body)
-            return True
-
     def list_apikeys(self, name):
         """Get the apikeys of the current user.
 
@@ -143,30 +129,4 @@ class UserAPI:
             code, body = res.status, res.read()
             if code != 200:
                 self.raise_error("Removing API key failed", res, body)
-            return True
-
-    def change_password(self, name, password):
-        """
-        TODO: remove
-        => True
-        """
-        params = {"password": password}
-        with self.post(
-            "/v3/user/password/change/%s" % (urlquote(str(name))), params
-        ) as res:
-            code, body = res.status, res.read()
-            if code != 200:
-                self.raise_error("Changing password failed", res, body)
-            return True
-
-    def change_my_password(self, old_password, password):
-        """
-        TODO: remove
-        => True
-        """
-        params = {"old_password": old_password, "password": password}
-        with self.post("/v3/user/password/change", params) as res:
-            code, body = res.status, res.read()
-            if code != 200:
-                self.raise_error("Changing password failed", res, body)
             return True


### PR DESCRIPTION
This PR removes:
1. `change_email`, `change_password `, `change_my_password ` methods those are not public API anymore
2. Unused authentication-related methods
3. Py2 dependent codes
4. item table related codes
5. `encoding` option for `msgpack.Unpacker`. Use `raw=False` instead
6. Deprecated options and methods like:
    - remove connect_timeout, read_timeout, send_timeout options for API
    - remove API.sleep, API.parsedate methods
    - remove JobAPI.hive_query, JobAPI.presto_query methods