### PR TITLE
Handle wait_interval argument of BulkImport.perform() appropriately

### DIFF
--- a/tdclient/bulk_import_model.py
+++ b/tdclient/bulk_import_model.py
@@ -117,6 +117,12 @@ class BulkImport(Model):
 
     def perform(self, wait=False, wait_interval=5, wait_callback=None):
         """Perform bulk import
+
+        Args:
+            wait (bool, optional): Flag for wait bulk import job. Default `False`
+            wait_interval (int, optional): wait interval in second. Default `5`.
+            wait_callback (callable, optional): A callable to be called on every tick of
+                wait interval.
         """
         self.update()
         if not self.upload_frozen:
@@ -125,7 +131,7 @@ class BulkImport(Model):
             )
         job = self._client.perform_bulk_import(self.name)
         if wait:
-            job.wait(wait_interval=wait_interval, wait_callback=None)
+            job.wait(wait_interval=wait_interval, wait_callback=wait_callback)
         self.update()
         return job
 

--- a/tdclient/job_model.py
+++ b/tdclient/job_model.py
@@ -204,7 +204,7 @@ class Job(Model):
         """
         return self._debug
 
-    def wait(self, timeout=None, wait_interval=5, wait_callback=None, callback=None):
+    def wait(self, timeout=None, wait_interval=5, wait_callback=None):
         """Sleep until the job has been finished
 
         Args:
@@ -212,22 +212,13 @@ class Job(Model):
             wait_interval (int, optional): wait interval in second. Default 5 seconds.
             wait_callback (callable, optional): A callable to be called on every tick of
                 wait interval.
-            callback (callable, optional): [Deprecated] Same behavior as `wait_callback`
-                for compatibility.
         """
-        if callback is not None:
-            warnings.warn(
-                "callback will be removed from future release. Please use wait_callback instaed.",
-                category=DeprecationWarning,
-            )
         started_at = time.time()
         while not self.finished():
             if timeout is None or abs(time.time() - started_at) < timeout:
                 time.sleep(wait_interval)
-                # TODO: remove `callback` argument
-                cb = wait_callback if callable(wait_callback) else callback
-                if callable(cb):
-                    cb(self)
+                if callable(wait_callback):
+                    wait_callback(self)
             else:
                 raise RuntimeError("timeout")  # TODO: throw proper error
         self.update()

--- a/tdclient/job_model.py
+++ b/tdclient/job_model.py
@@ -209,13 +209,22 @@ class Job(Model):
 
         Args:
             timeout (int, optional): Timeout in seconds. No timeout by default.
-            wait_interval (int): wait interval in second. Default 5 seconds.
-            wait_callback (callable): A callable to be called on every tick of wait interval.
+            wait_interval (int, optional): wait interval in second. Default 5 seconds.
+            wait_callback (callable, optional): A callable to be called on every tick of
+                wait interval.
+            callback (callable, optional): [Deprecated] Same behavior as `wait_callback`
+                for compatibility.
         """
+        if callback is not None:
+            warnings.warn(
+                "callback will be removed from future release. Please use wait_callback instaed.",
+                category=DeprecationWarning,
+            )
         started_at = time.time()
         while not self.finished():
             if timeout is None or abs(time.time() - started_at) < timeout:
                 time.sleep(wait_interval)
+                # TODO: remove `callback` argument
                 cb = wait_callback if callable(wait_callback) else callback
                 if callable(cb):
                     cb(self)


### PR DESCRIPTION
While `BulkImport.perform()` has `wait_callback` argument, but never used.

Also, remove `callback` argument in `Job.wait()`