### PR TITLE
Use io.TextIOWrapper to prevent "x85" issue creating None

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -617,10 +617,6 @@ class API(
     def _read_csv_file(
         self, file_like, dialect=csv.excel, columns=None, encoding="utf-8", **kwargs
     ):
-        def getreader(file_like):
-            for s in codecs.getreader(encoding)(file_like):
-                yield s
-
         def value(s):
             try:
                 return int(s)
@@ -638,13 +634,13 @@ class API(
                 return s
 
         if columns is None:
-            reader = csv.DictReader(getreader(file_like), dialect=dialect)
+            reader = csv.DictReader(io.TextIOWrapper(file_like, encoding), dialect=dialect)
             for row in reader:
                 record = {k: value(v) for (k, v) in row.items()}
                 self._validate_record(record)
                 yield record
         else:
-            reader = csv.reader(getreader(file_like), dialect=dialect)
+            reader = csv.reader(io.TextIOWrapper(file_like, encoding), dialect=dialect)
             for row in reader:
                 record = dict(zip(columns, [value(col) for col in row]))
                 self._validate_record(record)

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import codecs
 import contextlib
 import csv
 import email.utils

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -108,13 +108,11 @@ def value(s):
 
 def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
     """list -> bytes"""
-    stream = io.BytesIO()
-    _bytes = io.TextIOWrapper(stream, encoding)
-    writer = csv.writer(_bytes, dialect=dialect)
+    stream = io.StringIO()
+    writer = csv.writer(stream, dialect=dialect)
     for item in lis:
         writer.writerow([item.get(column) for column in columns])
-    _bytes.flush()
-    return stream.getvalue()
+    return stream.getvalue().encode(encoding)
 
 
 def uncsvb(bytes, columns=[], dialect=csv.excel, encoding="utf-8"):
@@ -127,17 +125,15 @@ def uncsvb(bytes, columns=[], dialect=csv.excel, encoding="utf-8"):
 def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
     """list -> bytes"""
     cols = lis[0].keys()
-    stream = io.BytesIO()
-    _bytes = io.TextIOWrapper(stream, encoding)
-    writer = csv.DictWriter(_bytes, cols, dialect=dialect)
+    stream = io.StringIO()
+    writer = csv.DictWriter(stream, cols, dialect=dialect)
     if hasattr(writer, "writeheader"):
         writer.writeheader()
     else:
         writer.writerow(dict(zip(cols, cols)))
     for item in lis:
         writer.writerow(item)
-    _bytes.flush()
-    return stream.getvalue()
+    return stream.getvalue().encode(encoding)
 
 
 def undcsvb(bytes, dialect=csv.excel, encoding="utf-8"):

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-import codecs
 import contextlib
 import csv
-import gzip
 import io
 import json
 import os
@@ -111,9 +109,11 @@ def value(s):
 def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
     """list -> bytes"""
     stream = io.BytesIO()
-    writer = csv.writer(codecs.getwriter(encoding)(stream), dialect=dialect)
+    _bytes = io.TextIOWrapper(stream, encoding)
+    writer = csv.writer(_bytes, dialect=dialect)
     for item in lis:
         writer.writerow([item.get(column) for column in columns])
+    _bytes.flush()
     return stream.getvalue()
 
 
@@ -128,19 +128,20 @@ def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
     """list -> bytes"""
     cols = lis[0].keys()
     stream = io.BytesIO()
-    writer = csv.DictWriter(codecs.getwriter(encoding)(stream), cols, dialect=dialect)
+    _bytes = io.TextIOWrapper(stream, encoding)
+    writer = csv.DictWriter(_bytes, cols, dialect=dialect)
     if hasattr(writer, "writeheader"):
         writer.writeheader()
     else:
         writer.writerow(dict(zip(cols, cols)))
     for item in lis:
         writer.writerow(item)
+    _bytes.flush()
     return stream.getvalue()
 
 
 def undcsvb(bytes, dialect=csv.excel, encoding="utf-8"):
     """bytes -> list"""
-    stream = bytes
     reader = csv.DictReader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
     return [dict([(k, value(v)) for (k, v) in row.items()]) for row in reader]
 


### PR DESCRIPTION
Fixes #76 

```py
n [1]: import pandas as pd

In [2]: import tdclient

In [3]: td = tdclient.Client()

In [4]: df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 10], 'col3': ['foo', "\x85."]})

In [5]: fname = "/tmp/foo.csv"

In [6]: df.to_csv(fname)

In [7]: import time

In [8]: session_name = f"session-{int(time.time())}"

In [10]: td.create_log_table("aki", "test")
Out[10]: True

In [23]: df['time'] = int(time.time())

In [24]: df.to_csv(fname)

In [25]: session_name = f"session-{int(time.time())}"

In [26]: bulk_import = td.create_bulk_import(session_name, "aki", "test")

In [27]: bulk_import.freeze()
Out[27]: True

In [29]: bulk_import.delete()
Out[29]: True

In [30]: session_name = f"session-{int(time.time())}"

In [31]: bulk_import = td.create_bulk_import(session_name, "aki", "test")

In [32]: bulk_import.upload_file("part", "csv", fname)

In [33]: bulk_import.freeze()
Out[33]: True

In [35]: bulk_import.perform(wait=True)
Out[35]: <tdclient.job_model.Job at 0x1154ae668>

In [36]: bulk_import.error_records
Out[36]: 0

In [37]: bulk_import.valid_records
Out[37]: 2

In [38]: bulk_import.commit(wait=True)
Out[38]: True

In [39]: bulk_import.delete()
Out[39]: True

In [42]: job = td.query("aki", "select * from test", type="presto")

In [46]: job.wait()

In [49]: list(job.result())
Out[49]: [[1, 3, 'foo', 1570499820], [2, 10, '\x85.', 1570499820]]
```
