### PR TITLE
Issue 83: Support explicit column datatypes in CSV

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Version History
 Unreleased
 ----------
 
+* Add new (optional) parameters to ``ImportApi.import_files``,
+  ``BulkImportApi.bulk_import_upload_file`` and ``BulkImport.upload_file``.
+  The ``dtypes`` and ``converters`` parameters allow better control of the
+  import of CSV data (#76). This is modelled on the approach taken by pandas.
+
 v1.1.0 (2019-10-16)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Unreleased
 * Add new (optional) parameters to ``ImportApi.import_files``,
   ``BulkImportApi.bulk_import_upload_file`` and ``BulkImport.upload_file``.
   The ``dtypes`` and ``converters`` parameters allow better control of the
-  import of CSV data (#76). This is modelled on the approach taken by pandas.
+  import of CSV data (#83). This is modelled on the approach taken by pandas.
 
 v1.1.0 (2019-10-16)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,13 @@ Examples
 
 Please see also the examples at `Treasure Data Documentation <http://docs.treasuredata.com/articles/rest-api-python-client>`_.
 
-If you want to find API reference, see also `API document <https://tdclient.readthedocs.io/>`_.
+The td-client documentation is hosted at https://tdclient.readthedocs.io/,
+or you can go directly to the
+`API documentation <https://tdclient.readthedocs.io/en/latest/api/index.html>`_.
+
+For information on the parameters that may be used when reading particular
+types of data, see
+`File import parameters <https://tdclient.readthedocs.io/en/latest/api/file_import_paremeters.html>`_.
 
 Listing jobs
 ^^^^^^^^^^^^

--- a/docs/api/misc.rst
+++ b/docs/api/misc.rst
@@ -18,13 +18,3 @@ tdclient.util
    :members:
    :undoc-members:
    :show-inheritance:
-
-
-
-tdclient.pseudo\_certifi
--------------------------------
-
-.. automodule:: tdclient.pseudo_certifi
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/file_import_parameters.rst
+++ b/docs/file_import_parameters.rst
@@ -1,8 +1,8 @@
 File import parameters
 ======================
 
-``file-like`` parameters specify where to read the input data from. They can
-be:
+``str or file-like`` parameters specify where to read the input data
+from. They can be:
 
 * a file name.
 * a file object, representing a file opened in binary mode.

--- a/docs/file_import_parameters.rst
+++ b/docs/file_import_parameters.rst
@@ -15,8 +15,8 @@ The following input formats are supported:
 * "msgpack" - the data is MessagePack_ serialized
 * "json" - the data is JSON_ serialized.
 * "csv" - the data is CSV, and will be read using the `Python CSV module`_.
-* "tsv" - the data is CSV, with ``dialect=csv.excel`` explicitly set, and will
-  be read using the Python CSV library.
+* "tsv" - the data is TSV (tab separated data), and will be read using the
+  `Python CSV module`_ with ``dialect=csv.excel_tab`` explicitly set.
 
 .. _`io.BufferedIOBase`: https://docs.python.org/3/library/io.html#io.BufferedIOBase
 .. _MessagePack: https://msgpack.org/
@@ -40,8 +40,8 @@ JSON data is read using the utf-8 encoding.
 CSV data
 --------
 
-When reading CSV data, the following parameters may also be supplied, all of
-which are optional:
+When reading CSV data, the following parameters may also be supplied,
+all of which are optional:
 
 * ``dialect`` specifies the CSV dialect. The default is ``csv.excel``.
 * ``encoding`` specifies the encoding that will be used to turn the binary
@@ -75,3 +75,14 @@ To summarise, the default for reading CSV files is:
 
   ``dialect=csv.excel, encoding="utf-8", columns=None, dtypes=None, converters=None``
   
+TSV data
+--------
+
+When reading TSV data, the parameters that may be used are the same as for
+CSV, except that:
+
+* ``dialect`` may not be specified, and ``csv.excel_tab`` will be used.
+
+The default for reading TSV files is:
+
+  ``encoding="utf-8", columns=None, dtypes=None, converters=None``

--- a/docs/file_import_parameters.rst
+++ b/docs/file_import_parameters.rst
@@ -1,0 +1,77 @@
+File import parameters
+======================
+
+``file-like`` parameters specify where to read the input data from. They can
+be:
+
+* a file name.
+* a file object, representing a file opened in binary mode.
+* an object that acts like an instance of `io.BufferedIOBase`_. Reading from it
+  returns bytes.
+
+``format`` is a string specifying an input format.
+The following input formats are supported:
+
+* "msgpack" - the data is MessagePack_ serialized
+* "json" - the data is JSON_ serialized.
+* "csv" - the data is CSV, and will be read using the `Python CSV module`_.
+* "tsv" - the data is CSV, with ``dialect=csv.excel`` explicitly set, and will
+  be read using the Python CSV library.
+
+.. _`io.BufferedIOBase`: https://docs.python.org/3/library/io.html#io.BufferedIOBase
+.. _MessagePack: https://msgpack.org/
+.. _JSON: https://www.json.org/
+.. _`Python CSV module`: https://docs.python.org/3/library/csv.html
+
+If ``.gz`` is appended to the format name (for instance, ``"json.gz"``) then
+the data is assumed to be gzip compressed, and will be uncompressed as it is
+read.
+
+Both MessagePack and JSON data are composed of an array of records, where each
+record is a dictionary (hash or mapping) of column name to column value.
+
+In all import formats, every record must have a column named "time".
+
+JSON data
+---------
+
+JSON data is read using the utf-8 encoding.
+
+CSV data
+--------
+
+When reading CSV data, the following parameters may also be supplied, all of
+which are optional:
+
+* ``dialect`` specifies the CSV dialect. The default is ``csv.excel``.
+* ``encoding`` specifies the encoding that will be used to turn the binary
+  input data into string data. The default encoding is ``"utf-8"``
+* ``columns`` is a list of strings, giving names for the CSV
+  columns. The default is ``None``, meaning that the column names will be
+  taken from the first record in the CSV data.
+* ``dtypes`` is a dictionary used to specify a datatype for individual
+  columns, for instance ``{"col1": "int"}``. The available datatypes are
+  ``"bool"``, ``"float"``, ``"int"``, ``"str"`` and ``"guess"``, where
+  ``"guess"`` means to use the function guess_csv_value_.
+* ``converters`` is a dictionary used to specify a function that will be used
+  to parse individual columns, for instace ``{"col1", int}``. The function
+  must take a string as its single input parameter, and return a value of the
+  required type.
+
+If a column is named in both ``dtypes`` and ``converters``, then the function
+given in ``converters`` will be used to parse that column.
+
+If a column is not named in either ``dtypes`` or ``converters``, then it will
+be assumed to have datatype ``"guess"``, and will be parsed with
+guess_csv_value_.
+
+Note that errors raised when calling a function from the ``converters``
+dictionary will not be caught. So if ``converters={"col1": int}`` and "col1"
+contains ``"not-an-int"``, the resulting ``ValueError`` will not be caught.
+
+.. _guess_csv_value: api/misc.html#tdclient.util.guess_csv_value
+
+To summarise, the default for reading CSV files is:
+
+  ``dialect=csv.excel, encoding="utf-8", columns=None, dtypes=None, converters=None``
+  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@
    :maxdepth: 1
    :caption: Contents
 
+   file_import_parameters
    api/index
    changelog
 

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -592,8 +592,14 @@ class API(
             yield record
 
     def _read_csv_file(
-        self, file_like, dialect=csv.excel, columns=None, encoding="utf-8",
-            dtypes=None, converters=None, **kwargs,
+        self,
+        file_like,
+        dialect=csv.excel,
+        columns=None,
+        encoding="utf-8",
+        dtypes=None,
+        converters=None,
+        **kwargs
     ):
         our_converters = merge_dtypes_and_converters(dtypes, converters)
 
@@ -602,7 +608,9 @@ class API(
                 io.TextIOWrapper(file_like, encoding), dialect=dialect
             )
             for row in reader:
-                record = {k: parse_csv_value(k, v, our_converters) for (k, v) in row.items()}
+                record = {
+                    k: parse_csv_value(k, v, our_converters) for (k, v) in row.items()
+                }
                 self._validate_record(record)
                 yield record
         else:

--- a/tdclient/bulk_import_api.py
+++ b/tdclient/bulk_import_api.py
@@ -164,7 +164,7 @@ class BulkImportAPI:
             part_name (str): Bulk import part name.
             format (str): Format name. {msgpack, json, csv, tsv}
             file (file-like): Byte string or file-like object contains the data.
-            **kwargs: Extra argments.
+            **kwargs: Extra arguments.
         """
         self.validate_part_name(part_name)
         with contextlib.closing(self._prepare_file(file, format, **kwargs)) as fp:

--- a/tdclient/bulk_import_api.py
+++ b/tdclient/bulk_import_api.py
@@ -163,8 +163,30 @@ class BulkImportAPI:
             name (str): Bulk import name.
             part_name (str): Bulk import part name.
             format (str): Format name. {msgpack, json, csv, tsv}
-            file (file-like): Byte string or file-like object contains the data.
+            file (str or file-like): the name of a file, or a file-like object,
+              containing the data
             **kwargs: Extra arguments.
+
+        There is more documentation on `format`, `file` and `**kwargs` at
+        `file import parameters`_.
+
+        In particular, for "csv" and "tsv" data, you can change how data columns
+        are parsed using the ``dtypes`` and ``converters`` arguments.
+
+        * ``dtypes`` is a dictionary used to specify a datatype for individual
+          columns, for instance ``{"col1": "int"}``. The available datatypes
+          are ``"bool"``, ``"float"``, ``"int"``, ``"str"`` and ``"guess"``.
+          If a column is also mentioned in ``converters``, then the function
+          will be used, NOT the datatype.
+
+        * ``converters`` is a dictionary used to specify a function that will
+          be used to parse individual columns, for instace ``{"col1", int}``.
+
+        The default behaviour is ``"guess"``, which makes a best-effort to decide
+        the column datatype. See `file import parameters`_ for more details.
+        
+        .. _`file import parameters`:
+           https://tdclient.readthedocs.io/en/latest/file_import_parameters.html
         """
         self.validate_part_name(part_name)
         with contextlib.closing(self._prepare_file(file, format, **kwargs)) as fp:

--- a/tdclient/bulk_import_model.py
+++ b/tdclient/bulk_import_model.py
@@ -179,9 +179,31 @@ class BulkImport(Model):
 
         Args:
             part_name (str): name of a part of the bulk import session
-            fmt (str): format of data type (e.g. "msgpack", "json")
-            file_like (str or file-like): a name of a file, or a file-like object contains the data
+            fmt (str): format of data type (e.g. "msgpack", "json", "csv", "tsv")
+            file_like (str or file-like): the name of a file, or a file-like object,
+              containing the data
             **kwargs: extra arguments.
+
+        There is more documentation on `fmt`, `file_like` and `**kwargs` at
+        `file import parameters`_.
+
+        In particular, for "csv" and "tsv" data, you can change how data columns
+        are parsed using the ``dtypes`` and ``converters`` arguments.
+
+        * ``dtypes`` is a dictionary used to specify a datatype for individual
+          columns, for instance ``{"col1": "int"}``. The available datatypes
+          are ``"bool"``, ``"float"``, ``"int"``, ``"str"`` and ``"guess"``.
+          If a column is also mentioned in ``converters``, then the function
+          will be used, NOT the datatype.
+
+        * ``converters`` is a dictionary used to specify a function that will
+          be used to parse individual columns, for instace ``{"col1", int}``.
+
+        The default behaviour is ``"guess"``, which makes a best-effort to decide
+        the column datatype. See `file import parameters`_ for more details.
+        
+        .. _`file import parameters`:
+           https://tdclient.readthedocs.io/en/latest/file_import_parameters.html
         """
         response = self._client.bulk_import_upload_file(
             self.name, part_name, fmt, file_like, **kwargs,

--- a/tdclient/bulk_import_model.py
+++ b/tdclient/bulk_import_model.py
@@ -174,16 +174,17 @@ class BulkImport(Model):
         self.update()
         return response
 
-    def upload_file(self, part_name, fmt, file_like):
+    def upload_file(self, part_name, fmt, file_like, **kwargs):
         """Upload a part to Bulk Import session, from an existing file on filesystem.
 
         Args:
             part_name (str): name of a part of the bulk import session
             fmt (str): format of data type (e.g. "msgpack", "json")
             file_like (str or file-like): a name of a file, or a file-like object contains the data
+            **kwargs: extra argments.
         """
         response = self._client.bulk_import_upload_file(
-            self.name, part_name, fmt, file_like
+            self.name, part_name, fmt, file_like, **kwargs,
         )
         self.update()
         return response

--- a/tdclient/bulk_import_model.py
+++ b/tdclient/bulk_import_model.py
@@ -181,7 +181,7 @@ class BulkImport(Model):
             part_name (str): name of a part of the bulk import session
             fmt (str): format of data type (e.g. "msgpack", "json")
             file_like (str or file-like): a name of a file, or a file-like object contains the data
-            **kwargs: extra argments.
+            **kwargs: extra arguments.
         """
         response = self._client.bulk_import_upload_file(
             self.name, part_name, fmt, file_like, **kwargs,

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -540,7 +540,7 @@ class Client:
         """
         return self.api.bulk_import_upload_part(name, part_name, bytes_or_stream, size)
 
-    def bulk_import_upload_file(self, name, part_name, format, file):
+    def bulk_import_upload_file(self, name, part_name, format, file, **kwargs):
         """Upload a part to Bulk Import session, from an existing file on filesystem.
 
         Args:
@@ -548,8 +548,9 @@ class Client:
             part_name (str): name of a part of the bulk import session
             format (str): format of data type (e.g. "msgpack", "json")
             file (str or file-like): a name of a file, or a file-like object contains the data
+            **kwargs: extra argments.
         """
-        return self.api.bulk_import_upload_file(name, part_name, format, file)
+        return self.api.bulk_import_upload_file(name, part_name, format, file, **kwargs)
 
     def bulk_import_delete_part(self, name, part_name):
         """Delete a part from a bulk import session

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -548,7 +548,7 @@ class Client:
             part_name (str): name of a part of the bulk import session
             format (str): format of data type (e.g. "msgpack", "json")
             file (str or file-like): a name of a file, or a file-like object contains the data
-            **kwargs: extra argments.
+            **kwargs: extra arguments.
         """
         return self.api.bulk_import_upload_file(name, part_name, format, file, **kwargs)
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -546,9 +546,31 @@ class Client:
         Args:
             name (str): name of a bulk import session
             part_name (str): name of a part of the bulk import session
-            format (str): format of data type (e.g. "msgpack", "json")
-            file (str or file-like): a name of a file, or a file-like object contains the data
+            format (str): format of data type (e.g. "msgpack", "json", "csv", "tsv")
+            file (str or file-like): the name of a file, or a file-like object,
+              containing the data
             **kwargs: extra arguments.
+
+        There is more documentation on `format`, `file` and `**kwargs` at
+        `file import parameters`_.
+
+        In particular, for "csv" and "tsv" data, you can change how data columns
+        are parsed using the ``dtypes`` and ``converters`` arguments.
+
+        * ``dtypes`` is a dictionary used to specify a datatype for individual
+          columns, for instance ``{"col1": "int"}``. The available datatypes
+          are ``"bool"``, ``"float"``, ``"int"``, ``"str"`` and ``"guess"``.
+          If a column is also mentioned in ``converters``, then the function
+          will be used, NOT the datatype.
+
+        * ``converters`` is a dictionary used to specify a function that will
+          be used to parse individual columns, for instace ``{"col1", int}``.
+
+        The default behaviour is ``"guess"``, which makes a best-effort to decide
+        the column datatype. See `file import parameters`_ for more details.
+        
+        .. _`file import parameters`:
+           https://tdclient.readthedocs.io/en/latest/file_import_parameters.html
         """
         return self.api.bulk_import_upload_file(name, part_name, format, file, **kwargs)
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -705,9 +705,18 @@ class Client:
         result = self.api.history(name, _from, to)
 
         def scheduled_job(m):
-            scheduled_at, job_id, type, status, query, start_at, end_at, result_url, priority, database = (
-                m
-            )
+            (
+                scheduled_at,
+                job_id,
+                type,
+                status,
+                query,
+                start_at,
+                end_at,
+                result_url,
+                priority,
+                database,
+            ) = m
             job_param = {
                 "url": None,
                 "debug": None,

--- a/tdclient/import_api.py
+++ b/tdclient/import_api.py
@@ -58,7 +58,7 @@ class ImportAPI:
 
         This method will decompress/deserialize records from given file, and then
         convert it into format acceptable from Treasure Data Service ("msgpack.gz").
-        This method is a warpper function to `import_data`.
+        This method is a wrapper function to `import_data`.
 
         Args:
             db (str): name of a database

--- a/tdclient/test/dtypes_and_converters_test.py
+++ b/tdclient/test/dtypes_and_converters_test.py
@@ -9,11 +9,6 @@ from io import BytesIO
 from unittest import mock
 
 from tdclient import api, Client
-from tdclient.util import DTYPE_TO_CALLABLE
-from tdclient.util import csv_dict_record_reader
-from tdclient.util import csv_text_record_reader
-from tdclient.util import merge_dtypes_and_converters
-from tdclient.util import parse_csv_value
 from tdclient.util import read_csv_records
 
 from tdclient.test.test_helper import gunzipb

--- a/tdclient/test/dtypes_and_converters_test.py
+++ b/tdclient/test/dtypes_and_converters_test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+
+"""Tests for the dtypes and converters arguments to CSV import.
+"""
+
+import pytest
+
+from io import BytesIO
+
+from tdclient import api
+from tdclient.util import DTYPE_TO_CALLABLE
+from tdclient.util import csv_dict_record_reader
+from tdclient.util import csv_text_record_reader
+from tdclient.util import merge_dtypes_and_converters
+from tdclient.util import parse_csv_value
+from tdclient.util import read_csv_records
+
+from tdclient.test.test_helper import gunzipb
+from tdclient.test.test_helper import msgunpackb
+
+
+DEFAULT_DATA = [
+    {'time': '100', 'col1': '0001', 'col2': '10', 'col3': '1.0', 'col4': 'abcd', 'col5': 'true', 'col6': 'none'},
+    {'time': '200', 'col1': '0002', 'col2': '20', 'col3': '2.0', 'col4': 'efgh', 'col5': 'false', 'col6': ''},
+]
+
+def sample_reader(data=DEFAULT_DATA):
+    """A very simple emulation of the actual CSV readers.
+    """
+    for item in data:
+        yield item
+
+
+def test_basic_read_csv_records():
+    """The base test of read_csv_records - no customisation.
+    """
+    reader = sample_reader()
+
+    result = list(read_csv_records(reader))
+
+    assert result == [
+        {'time': 100, 'col1': 1, 'col2': 10, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': None},
+        {'time': 200, 'col1': 2, 'col2': 20, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': None},
+    ]
+
+
+def test_unsupported_dtype_gives_error():
+    reader = sample_reader()
+
+    with pytest.raises(ValueError) as excinfo:
+        # Remember, it won't yield anything if we don't "next" it
+        next(read_csv_records(reader, dtypes={'something': 'no-such-dtype'}))
+    assert "Unrecognized dtype 'no-such-dtype'" in str(excinfo.value)
+
+
+def test_guess_dtype_gives_default_result():
+    reader = sample_reader()
+
+    result = list(read_csv_records(
+        reader,
+        dtypes = {
+            'time': 'guess',
+            'col1': 'guess',
+            'col2': 'guess',
+            'col3': 'guess',
+            'col4': 'guess',
+            'col5': 'guess',
+            'col6': 'guess',
+        }))
+
+    assert result == [
+        {'time': 100, 'col1': 1, 'col2': 10, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': None},
+        {'time': 200, 'col1': 2, 'col2': 20, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': None},
+    ]
+
+
+def test_dtypes_change_parsing():
+    reader = sample_reader()
+
+    result = list(read_csv_records(
+        reader,
+        dtypes = {
+            'col1': 'str',
+            'col2': 'float',
+            'col6': 'str',
+        }))
+
+    assert result == [
+        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
+        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+    ]
+
+
+def test_converters_change_parsing():
+    reader = sample_reader()
+
+    result = list(read_csv_records(
+        reader,
+        converters = {
+            'col1': str,
+            'col2': float,
+            'col6': str,
+        }))
+
+    assert result == [
+        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
+        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+    ]
+
+
+def test_dtypes_plus_converters_change_parsing():
+    reader = sample_reader()
+
+    result = list(read_csv_records(
+        reader,
+        dtypes = {
+            'col1': 'str',
+            'col6': 'str',
+        },
+        converters = {
+            'col2': float,
+        }))
+
+    assert result == [
+        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
+        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+    ]
+
+
+def test_dtypes_overridden_by_converters():
+    reader = sample_reader()
+
+    result = list(read_csv_records(
+        reader,
+        dtypes = {
+            'time': 'bool',  # overridden by converters
+            'col1': 'str',
+            'col2': 'int',   # overridden by converters
+            'col6': 'str',
+        },
+        converters = {
+            'time': int,
+            'col2': float,
+            'col5': str,
+        }))
+
+    assert result == [
+        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': 'true', 'col6': 'none'},
+        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': 'false', 'col6': ''},
+    ]
+
+
+DEFAULT_HEADER_BYTE_CSV = BytesIO(
+    b'time, col1, col2, col3, col4, col5, col6'
+    b'100, 0001, 10, 1.0, abcd, true, none'
+    b'200, 0002, 20, 2.0, edfg, false,'
+)
+
+
+DEFAULT_NO_HEADER_BYTE_CSV = BytesIO(
+    b'100, 0001, 10, 1.0, abcd, true, none'
+    b'200, 0002, 20, 2.0, edfg, false,'
+)
+
+DEFAULT_COLUMNS = ['time', 'col1', 'col2', 'col3', 'col4', 'col5', 'col6']
+
+
+def test_import_file_supports_empty_dtypes_and_converters():
+    expected_data = [
+        {'time': '100', 'col1': '0001', 'col2': '10', 'col3': '1.0', 'col4': 'abcd', 'col5': 'true', 'col6': 'none'},
+        {'time': '200', 'col1': '0002', 'col2': '20', 'col3': '2.0', 'col4': 'efgh', 'col5': 'false', 'col6': ''},
+    ]
+    td = api.API("APIKEY")
+
+    def import_data(db, table, format, stream, size, unique_id=None):
+        assert db == "db"
+        assert table == "table"
+        assert format == "msgpack.gz"
+        print(f'size {size}')
+        data = stream.read(size)
+        print(f'data {data!r}')
+        print(f'data {gunzipb(data)!r}')
+        assert msgunpackb(gunzipb(data)) == expected_data
+        assert unique_id is None
+
+    td.import_data = import_data
+    td.import_file("db", "table", "csv", DEFAULT_HEADER_BYTE_CSV)
+
+
+def test_import_file_supports_dtypes_and_converters():
+    pass
+
+
+def test_import_file_no_headers_supports_dtypes_and_converters():
+    pass
+
+
+def test_bulk_import_upload_file_supports_dtypes_and_converters():
+    pass
+
+
+def test_bulk_import_dot_upload_file_supports_dtypes_and_converters():
+    pass

--- a/tdclient/test/dtypes_and_converters_test.py
+++ b/tdclient/test/dtypes_and_converters_test.py
@@ -17,9 +17,26 @@ from tdclient.test.test_helper import msgunpackb
 
 
 DEFAULT_DATA = [
-    {'time': '100', 'col1': '0001', 'col2': '10', 'col3': '1.0', 'col4': 'abcd', 'col5': 'true', 'col6': 'none'},
-    {'time': '200', 'col1': '0002', 'col2': '20', 'col3': '2.0', 'col4': 'efgh', 'col5': 'false', 'col6': ''},
+    {
+        "time": "100",
+        "col1": "0001",
+        "col2": "10",
+        "col3": "1.0",
+        "col4": "abcd",
+        "col5": "true",
+        "col6": "none",
+    },
+    {
+        "time": "200",
+        "col1": "0002",
+        "col2": "20",
+        "col3": "2.0",
+        "col4": "efgh",
+        "col5": "false",
+        "col6": "",
+    },
 ]
+
 
 def sample_reader(data=DEFAULT_DATA):
     """A very simple emulation of the actual CSV readers.
@@ -36,8 +53,24 @@ def test_basic_read_csv_records():
     result = list(read_csv_records(reader))
 
     assert result == [
-        {'time': 100, 'col1': 1, 'col2': 10, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': None},
-        {'time': 200, 'col1': 2, 'col2': 20, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': None},
+        {
+            "time": 100,
+            "col1": 1,
+            "col2": 10,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": True,
+            "col6": None,
+        },
+        {
+            "time": 200,
+            "col1": 2,
+            "col2": 20,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": False,
+            "col6": None,
+        },
     ]
 
 
@@ -46,169 +79,241 @@ def test_unsupported_dtype_gives_error():
 
     with pytest.raises(ValueError) as excinfo:
         # Remember, it won't yield anything if we don't "next" it
-        next(read_csv_records(reader, dtypes={'something': 'no-such-dtype'}))
+        next(read_csv_records(reader, dtypes={"something": "no-such-dtype"}))
     assert "Unrecognized dtype 'no-such-dtype'" in str(excinfo.value)
 
 
 def test_guess_dtype_gives_default_result():
     reader = sample_reader()
 
-    result = list(read_csv_records(
-        reader,
-        dtypes = {
-            'time': 'guess',
-            'col1': 'guess',
-            'col2': 'guess',
-            'col3': 'guess',
-            'col4': 'guess',
-            'col5': 'guess',
-            'col6': 'guess',
-        }))
+    result = list(
+        read_csv_records(
+            reader,
+            dtypes={
+                "time": "guess",
+                "col1": "guess",
+                "col2": "guess",
+                "col3": "guess",
+                "col4": "guess",
+                "col5": "guess",
+                "col6": "guess",
+            },
+        )
+    )
 
     assert result == [
-        {'time': 100, 'col1': 1, 'col2': 10, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': None},
-        {'time': 200, 'col1': 2, 'col2': 20, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': None},
+        {
+            "time": 100,
+            "col1": 1,
+            "col2": 10,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": True,
+            "col6": None,
+        },
+        {
+            "time": 200,
+            "col1": 2,
+            "col2": 20,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": False,
+            "col6": None,
+        },
     ]
 
 
 def test_dtypes_change_parsing():
     reader = sample_reader()
 
-    result = list(read_csv_records(
-        reader,
-        dtypes = {
-            'col1': 'str',
-            'col2': 'float',
-            'col6': 'str',
-        }))
+    result = list(
+        read_csv_records(
+            reader, dtypes={"col1": "str", "col2": "float", "col6": "str",}
+        )
+    )
 
     assert result == [
-        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
-        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+        {
+            "time": 100,
+            "col1": "0001",
+            "col2": 10.0,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": True,
+            "col6": "none",
+        },
+        {
+            "time": 200,
+            "col1": "0002",
+            "col2": 20.0,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": False,
+            "col6": "",
+        },
     ]
 
 
 def test_converters_change_parsing():
     reader = sample_reader()
 
-    result = list(read_csv_records(
-        reader,
-        converters = {
-            'col1': str,
-            'col2': float,
-            'col6': str,
-        }))
+    result = list(
+        read_csv_records(reader, converters={"col1": str, "col2": float, "col6": str,})
+    )
 
     assert result == [
-        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
-        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+        {
+            "time": 100,
+            "col1": "0001",
+            "col2": 10.0,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": True,
+            "col6": "none",
+        },
+        {
+            "time": 200,
+            "col1": "0002",
+            "col2": 20.0,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": False,
+            "col6": "",
+        },
     ]
 
 
 def test_dtypes_plus_converters_change_parsing():
     reader = sample_reader()
 
-    result = list(read_csv_records(
-        reader,
-        dtypes = {
-            'col1': 'str',
-            'col6': 'str',
-        },
-        converters = {
-            'col2': float,
-        }))
+    result = list(
+        read_csv_records(
+            reader, dtypes={"col1": "str", "col6": "str",}, converters={"col2": float,}
+        )
+    )
 
     assert result == [
-        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': True, 'col6': 'none'},
-        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': False, 'col6': ''},
+        {
+            "time": 100,
+            "col1": "0001",
+            "col2": 10.0,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": True,
+            "col6": "none",
+        },
+        {
+            "time": 200,
+            "col1": "0002",
+            "col2": 20.0,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": False,
+            "col6": "",
+        },
     ]
 
 
 def test_dtypes_overridden_by_converters():
     reader = sample_reader()
 
-    result = list(read_csv_records(
-        reader,
-        dtypes = {
-            'time': 'bool',  # overridden by converters
-            'col1': 'str',
-            'col2': 'int',   # overridden by converters
-            'col6': 'str',
-        },
-        converters = {
-            'time': int,
-            'col2': float,
-            'col5': str,
-        }))
+    result = list(
+        read_csv_records(
+            reader,
+            dtypes={
+                "time": "bool",  # overridden by converters
+                "col1": "str",
+                "col2": "int",  # overridden by converters
+                "col6": "str",
+            },
+            converters={"time": int, "col2": float, "col5": str,},
+        )
+    )
 
     assert result == [
-        {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd', 'col5': 'true', 'col6': 'none'},
-        {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh', 'col5': 'false', 'col6': ''},
+        {
+            "time": 100,
+            "col1": "0001",
+            "col2": 10.0,
+            "col3": 1.0,
+            "col4": "abcd",
+            "col5": "true",
+            "col6": "none",
+        },
+        {
+            "time": 200,
+            "col1": "0002",
+            "col2": 20.0,
+            "col3": 2.0,
+            "col4": "efgh",
+            "col5": "false",
+            "col6": "",
+        },
     ]
 
 
 DEFAULT_HEADER_BYTE_CSV = (
-    b'time,col1,col2,col3,col4\n'
-    b'100,0001,10,1.0,abcd\n'
-    b'200,0002,20,2.0,efgh\n'
+    b"time,col1,col2,col3,col4\n" b"100,0001,10,1.0,abcd\n" b"200,0002,20,2.0,efgh\n"
 )
 
 
 def test_import_file_supports_dtypes_and_converters():
-
     def import_data(db, table, format, stream, size, unique_id=None):
         data = stream.read(size)
-        assert msgunpackb(gunzipb(data)) == \
-            [
-                {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd'},
-                {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh'},
-            ]
+        assert msgunpackb(gunzipb(data)) == [
+            {"time": 100, "col1": "0001", "col2": 10.0, "col3": 1.0, "col4": "abcd"},
+            {"time": 200, "col1": "0002", "col2": 20.0, "col3": 2.0, "col4": "efgh"},
+        ]
 
     td = api.API("APIKEY")
     td.import_data = import_data
     td.import_file(
-        "db", "table", "csv", BytesIO(DEFAULT_HEADER_BYTE_CSV),
-        dtypes = {'col1': 'str', 'col6': 'str'},
-        converters = {'col2': float},
+        "db",
+        "table",
+        "csv",
+        BytesIO(DEFAULT_HEADER_BYTE_CSV),
+        dtypes={"col1": "str", "col6": "str"},
+        converters={"col2": float},
     )
 
 
 def test_bulk_import_upload_file_supports_dtypes_and_converters():
-
     def bulk_import_upload_part(name, part_name, stream, size):
         data = stream.read(size)
-        assert msgunpackb(gunzipb(data)) == \
-            [
-                {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd'},
-                {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh'},
-            ]
+        assert msgunpackb(gunzipb(data)) == [
+            {"time": 100, "col1": "0001", "col2": 10.0, "col3": 1.0, "col4": "abcd"},
+            {"time": 200, "col1": "0002", "col2": 20.0, "col3": 2.0, "col4": "efgh"},
+        ]
 
     td = api.API("APIKEY")
     td.bulk_import_upload_part = bulk_import_upload_part
     td.bulk_import_upload_file(
-        "name", "part-name", "csv", BytesIO(DEFAULT_HEADER_BYTE_CSV),
-        dtypes = {'col1': 'str', 'col6': 'str'},
-        converters = {'col2': float},
+        "name",
+        "part-name",
+        "csv",
+        BytesIO(DEFAULT_HEADER_BYTE_CSV),
+        dtypes={"col1": "str", "col6": "str"},
+        converters={"col2": float},
     )
 
 
 def test_bulk_import_dot_upload_file_supports_dtypes_and_converters():
-
     def bulk_import_upload_part(name, part_name, stream, size):
         data = stream.read(size)
-        assert msgunpackb(gunzipb(data)) == \
-            [
-                {'time': 100, 'col1': '0001', 'col2': 10.0, 'col3': 1.0, 'col4': 'abcd'},
-                {'time': 200, 'col1': '0002', 'col2': 20.0, 'col3': 2.0, 'col4': 'efgh'},
-            ]
+        assert msgunpackb(gunzipb(data)) == [
+            {"time": 100, "col1": "0001", "col2": 10.0, "col3": 1.0, "col4": "abcd"},
+            {"time": 200, "col1": "0002", "col2": 20.0, "col3": 2.0, "col4": "efgh"},
+        ]
 
     with Client("APIKEY") as td:
         td.api.post = mock.MagicMock(return_value=make_response(200, b""))
         td.api.bulk_import_upload_part = bulk_import_upload_part
-        bulk_import = td.create_bulk_import('session-name', 'mydb', 'mytbl')
+        bulk_import = td.create_bulk_import("session-name", "mydb", "mytbl")
         bulk_import.update = mock.MagicMock()
         bulk_import.upload_file(
-            'part-name', 'csv', BytesIO(DEFAULT_HEADER_BYTE_CSV),
-            dtypes = {'col1': 'str', 'col6': 'str'},
-            converters = {'col2': float},
+            "part-name",
+            "csv",
+            BytesIO(DEFAULT_HEADER_BYTE_CSV),
+            dtypes={"col1": "str", "col6": "str"},
+            converters={"col2": float},
         )

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -80,8 +80,8 @@ def unjsonb(bytes):
     return [json.loads(s.decode("utf-8")) for s in bytes.splitlines()]
 
 
-def value(s):
-    return parse_csv_value(s)
+# def value(s):
+#     return parse_csv_value(s)
 
 
 def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
@@ -93,11 +93,11 @@ def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
     return stream.getvalue().encode(encoding)
 
 
-def uncsvb(bytes, columns=[], dialect=csv.excel, encoding="utf-8"):
-    """bytes -> list"""
-    stream = bytes
-    reader = csv.reader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
-    return [dict(zip(columns, [value(column) for column in row])) for row in reader]
+# def uncsvb(bytes, columns=[], dialect=csv.excel, encoding="utf-8"):
+#     """bytes -> list"""
+#     stream = bytes
+#     reader = csv.reader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
+#     return [dict(zip(columns, [value(column) for column in row])) for row in reader]
 
 
 def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
@@ -114,10 +114,10 @@ def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
     return stream.getvalue().encode(encoding)
 
 
-def undcsvb(bytes, dialect=csv.excel, encoding="utf-8"):
-    """bytes -> list"""
-    reader = csv.DictReader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
-    return [dict([(k, value(v)) for (k, v) in row.items()]) for row in reader]
+# def undcsvb(bytes, dialect=csv.excel, encoding="utf-8"):
+#     """bytes -> list"""
+#     reader = csv.DictReader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
+#     return [dict([(k, value(v)) for (k, v) in row.items()]) for row in reader]
 
 
 def tsvb(lis, columns=[], encoding="utf-8"):

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -80,10 +80,6 @@ def unjsonb(bytes):
     return [json.loads(s.decode("utf-8")) for s in bytes.splitlines()]
 
 
-# def value(s):
-#     return parse_csv_value(s)
-
-
 def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
     """list -> bytes"""
     stream = io.StringIO()
@@ -91,13 +87,6 @@ def csvb(lis, columns=[], dialect=csv.excel, encoding="utf-8"):
     for item in lis:
         writer.writerow([item.get(column) for column in columns])
     return stream.getvalue().encode(encoding)
-
-
-# def uncsvb(bytes, columns=[], dialect=csv.excel, encoding="utf-8"):
-#     """bytes -> list"""
-#     stream = bytes
-#     reader = csv.reader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
-#     return [dict(zip(columns, [value(column) for column in row])) for row in reader]
 
 
 def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
@@ -112,12 +101,6 @@ def dcsvb(lis, dialect=csv.excel, encoding="utf-8"):
     for item in lis:
         writer.writerow(item)
     return stream.getvalue().encode(encoding)
-
-
-# def undcsvb(bytes, dialect=csv.excel, encoding="utf-8"):
-#     """bytes -> list"""
-#     reader = csv.DictReader(io.StringIO(bytes.decode(encoding)), dialect=dialect)
-#     return [dict([(k, value(v)) for (k, v) in row.items()]) for row in reader]
 
 
 def tsvb(lis, columns=[], encoding="utf-8"):

--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -55,11 +55,11 @@ def guess_csv_value(s):
 
 # Convert our dtype names to callables that parse a string into that type
 DTYPE_TO_CALLABLE = {
-    'bool': bool,
-    'float': float,
-    'int': int,
-    'str': str,
-    'guess': guess_csv_value,
+    "bool": bool,
+    "float": float,
+    "int": int,
+    "str": str,
+    "guess": guess_csv_value,
 }
 
 

--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -23,10 +23,16 @@ def create_url(tmpl, **values):
 
 
 def validate_record(record):
-    """All input records should contain a column named "time".
+    """Check that `record` contains a key called "time".
+    
+    Args:
+        record (dict): a dictionary representing a data record, where the
+        keys name the "columns".
 
-    Since we represent records internally as dictionaries, this means
-    all record *dictionaries* should contain a key called "time".
+    Returns:
+        True if there is a key called "time" (it actually checks for ``"time"``
+        (a string) and ``b"time"`` (a binary)). False if there is no key
+        called "time".
     """
     if not any(k in record for k in ("time", b"time")):
         warnings.warn(
@@ -37,21 +43,21 @@ def validate_record(record):
 
 
 def guess_csv_value(s):
-    """Given a (string) CSV value, try to guess its type and return it
+    """Determine the most appropriate type for `s` and return it.
 
-    Tries to interpret s. It tries each interpretation in turn, and returns
-    the first that succeeds:
+    Tries to interpret `s` as a more specific datatype, in the following
+    order, and returns the first that succeeds:
 
     1. As an integer
     2. As a floating point value
     3. If it is "false" or "true" (case insensitive), then as a boolean
     4. If it is "" or "none" or "null" (case insensitive), then as None
     5. As the string itself, unaltered
-
+    
     Args:
-        s (str): value on csv
+        s (str): a string value, assumed to have been read from a CSV file.
     Returns:
-        Suitable value (int, float, str, bool or None)
+        A good guess at a more specific value (int, float, str, bool or None)
     """
     try:
         return int(s)
@@ -80,7 +86,33 @@ DTYPE_TO_CALLABLE = {
 
 
 def merge_dtypes_and_converters(dtypes=None, converters=None):
-    """Generate a merged converters dictionary from the user supplied dicts.
+    """Generate a merged dictionary from those given.
+    
+    Args:
+        dtypes (optional dict): A dictionary mapping column name to "dtype"
+          (datatype), where "dtype" may be any of the strings 'bool', 'float',
+          'int', 'str' or 'guess'.
+        converters (optional dict): A dictionary mapping column name to a
+          callable. The callable should take a string as its single argument,
+          and return the result of parsing that string.
+    
+    Internally, the `dtypes` dictionary is converted to a temporary dictionary
+    of the same form as `converters` - that is, mapping column names to
+    callables. The "data type" string values in `dtypes` are converted to the
+    Python builtins of the same name, and the value `"guess"` is converted to
+    the `tdclient.util.guess_csv_value`_ callable.
+
+    Example:
+        >>> merge_dtypes_and_converters(
+        ...    dtypes={'col1': 'int', 'col2': 'float'},
+        ...    converters={'col2': int},
+        ... )
+        {'col1': int, 'col2': int}
+
+    Returns:
+        (dict) A dictionary which maps column names to callables.
+        If a column name occurs in both input dictionaries, the callable
+        specified in `converters` is used.
     """
     our_converters = {}
     if dtypes is not None:
@@ -97,7 +129,35 @@ def merge_dtypes_and_converters(dtypes=None, converters=None):
 
 
 def parse_csv_value(k, s, converters=None):
-    """
+    """Given a CSV (string) value, work out an actual value.
+
+    Args:
+        k (str): The name of the column that the value belongs to.
+        s (str): The value as read from the CSV input.
+        converters (optional dict): A dictionary mapping column name to callable.
+    
+    If `converters` is given, and there is a key matching `k` in `converters`,
+    then ``converters[k](s)`` will be called to work out the return value.
+    Otherwise, `tdclient.util.guess_csv_value`_ will be called with `s` as its
+    argument.
+
+    .. warning:: No attempt is made to cope with any errors occurring in a
+       callable from the `converters` dictionary. So if ``int`` is called
+       on the string ``"not-an-int"`` the resulting ``ValueError`` is not
+       caught.
+
+    Example:
+
+        >>> repr(parse_csv_value('col1', 'A string'))
+        'A string'
+        >>> repr(parse_csv_value('col1', '10'))
+        10
+        >>> repr(parse_csv_value('col1', '10', {'col1': float, 'col2': int}))
+        10.0
+
+    Returns:
+        The value for the CSV column, after parsing by a callable from
+        `converters`, or after parsing by `tdclient.util.guess_csv_value`_.
     """
     if converters is None:
         parse_fn = guess_csv_value
@@ -107,19 +167,24 @@ def parse_csv_value(k, s, converters=None):
 
 
 def csv_dict_record_reader(file_like, encoding, dialect):
-    """Yield records from a CSV "file" using csv.DictReader.
+    """Yield records from a CSV input using csv.DictReader.
+    
+    This is a reader suitable for use by `tdclient.util.read_csv_records`_.
+    
+    It is used to read CSV data when the column names are read from the first
+    row in the CSV data.
 
     Args:
-        file_like: acts like an instance of io.BufferedIOBase, returning
-            bytes when it is read from.
-        encoding (str): then name of the encoding to use when turning those
+        file_like: acts like an instance of io.BufferedIOBase. Reading from it
+            returns bytes.
+        encoding (str): the name of the encoding to use when turning those
             bytes into strings.
-        dialect (str or None): the name of the CSV dialect to use, or None.
+        dialect (str): the name of the CSV dialect to use.
 
     Yields:
-        For each CSV row, yields a dictionary whose keys are column names
-        (determined by the first row in the CSV data) and whose values are
-        column values.
+        For each row of CSV data read from `file_like`, yields a dictionary
+        whose keys are column names (determined from the first row in the CSV
+        data) and whose values are the column values.
     """
     reader = csv.DictReader(
         io.TextIOWrapper(file_like, encoding), dialect=dialect
@@ -129,18 +194,24 @@ def csv_dict_record_reader(file_like, encoding, dialect):
 
 
 def csv_text_record_reader(file_like, encoding, dialect, columns):
-    """Yield records from a CSV "file" using csv.reader and given column names.
+    """Yield records from a CSV input using csv.reader and explicit column names.
+    
+    This is a reader suitable for use by `tdclient.util.read_csv_records`_.
+    
+    It is used to read CSV data when the column names are supplied as an
+    explicit `columns` parameter.
 
     Args:
-        file_like: acts like an instance of io.BufferedIOBase, returning
-            bytes when it is read from.
-        encoding (str): then name of the encoding to use when turning those
+        file_like: acts like an instance of io.BufferedIOBase. Reading from it
+            returns bytes.
+        encoding (str): the name of the encoding to use when turning those
             bytes into strings.
-        dialect (str or None): the name of the CSV dialect to use, or None.
+        dialect (str): the name of the CSV dialect to use.
 
     Yields:
-        For each CSV row, yields a dictionary whose keys are column names
-        (determined by `columns`) and whose values are column values.
+        For each row of CSV data read from `file_like`, yields a dictionary
+        whose keys are column names (determined by `columns`) and whose values
+        are the column values.
     """
     reader = csv.reader(
         io.TextIOWrapper(file_like, encoding), dialect=dialect
@@ -177,7 +248,7 @@ def create_msgpack(items):
         >>> t1 = int(time.time())
         >>> l1 = [{"a": 1, "b": 2, "time": t1}, {"a":3, "b": 6, "time": t1}]
         >>> create_msgpack(l1)
-        ``b'\x83\xa1a\x01\xa1b\x02\xa4time\xce]\xa5X\xa1\x83\xa1a\x03\xa1b\x06\xa4time\xce]\xa5X\xa1'``
+        b'\\x83\\xa1a\\x01\\xa1b\\x02\\xa4time\\xce]\\xa5X\\xa1\\x83\\xa1a\\x03\\xa1b\\x06\\xa4time\\xce]\\xa5X\\xa1'
     """
     stream = io.BytesIO()
     packer = msgpack.Packer()
@@ -193,10 +264,21 @@ def create_msgpack(items):
 
 
 def normalized_msgpack(value):
-    """Convert int to str if overflow
+    """Recursively convert int to str if the int "overflows".
 
     Args:
-        value (int, float, str, bool or None): value to be normalized
+        value (list, dict, int, float, str, bool or None): value to be normalized
+
+    If `value` is a list, then all elements in the list are (recursively)
+    normalized.
+
+    If `value` is a dictionary, then all the dictionary keys and values are
+    (recursively) normalized.
+    
+    If `value` is an integer, and outside the range ``-(1 << 63)`` to
+    ``(1 << 64)``, then it is converted to a string.
+
+    Otherwise, `value` is returned unchanged.
 
     Returns:
         Normalized value
@@ -219,12 +301,27 @@ def normalized_msgpack(value):
 
 def get_or_else(hashmap, key, default_value=None):
     """ Get value or default value
+    
+    It differs from the standard dict ``get`` method in its behaviour when
+    `key` is present but has a value that is an empty string or a string of
+    only spaces.
+
     Args:
         hashmap (dict): target
         key (Any): key
         default_value (Any): default value
+    
+    Example:
+
+        >>> get_or_else({'k': 'nonspace'}, 'k', 'default')
+        'nonspace'
+        >>> get_or_else({'k': ''}, 'k', 'default')
+        'default'
+        >>> get_or_else({'k': '    '}, 'k', 'default')
+        'default'
+
     Returns:
-        value of key or default_value
+        The value of `key` or `default_value`
     """
     value = hashmap.get(key)
     if value is None:
@@ -237,14 +334,15 @@ def get_or_else(hashmap, key, default_value=None):
 
 
 def parse_date(s):
-    """Parse date from str to datetime using fmt
+    """Parse date from str to datetime
 
-    TODO: parse datetime with using format string
-    for now, this ignores given format string since API may return date in ambiguous format :(
+    TODO: parse datetime using an optional format string
+    
+    For now, this does not use a format string since API may return date in ambiguous format :(
 
     Args:
        s (str): target str
-       fmt (str): format for datetime
+
     Returns:
        datetime
     """

--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -88,8 +88,8 @@ def merge_dtypes_and_converters(dtypes=None, converters=None):
             for column_name, dtype in dtypes.items():
                 our_converters[column_name] = DTYPE_TO_CALLABLE[dtype]
         except KeyError as e:
-            raise ValueError(f'Unrecognized dtype {dtype!r}, must be one of '
-                             f'{", ".join(repr(k) for k in sorted(DTYPE_TO_CALLABLE))}')
+            raise ValueError('Unrecognized dtype %r, must be one of %s' % (
+                dtype, ", ".join(repr(k) for k in sorted(DTYPE_TO_CALLABLE))))
     if converters is not None:
         for column_name, parse_fn in converters.items():
             our_converters[column_name] = parse_fn

--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -120,8 +120,10 @@ def merge_dtypes_and_converters(dtypes=None, converters=None):
             for column_name, dtype in dtypes.items():
                 our_converters[column_name] = DTYPE_TO_CALLABLE[dtype]
         except KeyError as e:
-            raise ValueError('Unrecognized dtype %r, must be one of %s' % (
-                dtype, ", ".join(repr(k) for k in sorted(DTYPE_TO_CALLABLE))))
+            raise ValueError(
+                "Unrecognized dtype %r, must be one of %s"
+                % (dtype, ", ".join(repr(k) for k in sorted(DTYPE_TO_CALLABLE)))
+            )
     if converters is not None:
         for column_name, parse_fn in converters.items():
             our_converters[column_name] = parse_fn
@@ -186,9 +188,7 @@ def csv_dict_record_reader(file_like, encoding, dialect):
         whose keys are column names (determined from the first row in the CSV
         data) and whose values are the column values.
     """
-    reader = csv.DictReader(
-        io.TextIOWrapper(file_like, encoding), dialect=dialect
-    )
+    reader = csv.DictReader(io.TextIOWrapper(file_like, encoding), dialect=dialect)
     for row in reader:
         yield row
 
@@ -213,9 +213,7 @@ def csv_text_record_reader(file_like, encoding, dialect, columns):
         whose keys are column names (determined by `columns`) and whose values
         are the column values.
     """
-    reader = csv.reader(
-        io.TextIOWrapper(file_like, encoding), dialect=dialect
-    )
+    reader = csv.reader(io.TextIOWrapper(file_like, encoding), dialect=dialect)
     for row in reader:
         yield dict(zip(columns, row))
 
@@ -227,9 +225,7 @@ def read_csv_records(csv_reader, dtypes=None, converters=None, **kwargs):
     our_converters = merge_dtypes_and_converters(dtypes, converters)
 
     for row in csv_reader:
-        record = {
-            k: parse_csv_value(k, v, our_converters) for (k, v) in row.items()
-        }
+        record = {k: parse_csv_value(k, v, our_converters) for (k, v) in row.items()}
         validate_record(record)
         yield record
 

--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -53,7 +53,6 @@ def guess_csv_value(s):
     Returns:
         Suitable value (int, float, str, bool or None)
     """
-    print(f'guess {s!r}')
     try:
         return int(s)
     except (OverflowError, ValueError):


### PR DESCRIPTION
Add new (optional) parameters to `ImportApi.import_files`, `BulkImportApi.bulk_import_upload_file` and `BulkImport.upload_file`.

The `dtypes` and `converters` parameters allow better control of the import of CSV data. This is modelled on the approach taken by pandas.

Existing tests pass, and new tests also pass. Coverage has gone up, and the new code is covered.

Extra documentation has been added to cover the possibilities for `**kwargs` arguments when processing CSV data, and some extra description of what `file-like` means (I hope this is useful for those, like me, who are new to the library).

While I was writing docstrings for the new functions in utils.py, I also updated some of the other docstrings in that same file.