### PR TITLE
Use msgpack v0 instead of v1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="support@treasure-data.com",
     url="http://treasuredata.com/",
     python_requires=">=3.5",
-    install_requires=["msgpack>=0.5.2", "python-dateutil", "urllib3"],
+    install_requires=["msgpack==0.6.2", "python-dateutil", "urllib3"],
     tests_require=["coveralls", "mock", "pytest", "pytest-cov", "tox"],
     extras_require={
         "dev": ["black==19.3b0", "isort", "flake8"],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="support@treasure-data.com",
     url="http://treasuredata.com/",
     python_requires=">=3.5",
-    install_requires=["msgpack==0.6.2", "python-dateutil", "urllib3"],
+    install_requires=["msgpack>=0.6.2,<1.0.0", "python-dateutil", "urllib3"],
     tests_require=["coveralls", "mock", "pytest", "pytest-cov", "tox"],
     extras_require={
         "dev": ["black==19.3b0", "isort", "flake8"],


### PR DESCRIPTION
td-client-python doesn't work with msgpack-v1.0.0.
This fix forces to install msgpack v0.6.2 since it is the latest version and it's same as requirements.tx

```
$ pip install td-client
Collecting td-client
  Using cached td_client-1.2.0-py3-none-any.whl (86 kB)
Collecting msgpack>=0.5.2
  Downloading msgpack-1.0.0-cp37-cp37m-macosx_10_13_x86_64.whl (78 kB)
     |████████████████████████████████| 78 kB 3.6 MB/s 
Requirement already satisfied: python-dateutil in ./.pyenv/versions/3.7.4/lib/python3.7/site-packages (from td-client) (2.8.0)
Requirement already satisfied: urllib3 in ./.pyenv/versions/3.7.4/lib/python3.7/site-packages (from td-client) (1.24.3)
Requirement already satisfied: six>=1.5 in ./.pyenv/versions/3.7.4/lib/python3.7/site-packages (from python-dateutil->td-client) (1.12.0)
Installing collected packages: msgpack, td-client
Successfully installed msgpack-1.0.0 td-client-1.2.0
```