### PR TITLE
Revert "Merge pull request #89 from treasure-data/msgpack-version"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="support@treasure-data.com",
     url="http://treasuredata.com/",
     python_requires=">=3.5",
-    install_requires=["msgpack>=0.6.2,<1.0.0", "python-dateutil", "urllib3"],
+    install_requires=["msgpack>=0.5.2", "python-dateutil", "urllib3"],
     tests_require=["coveralls", "mock", "pytest", "pytest-cov", "tox"],
     extras_require={
         "dev": ["black==19.3b0", "isort", "flake8"],


### PR DESCRIPTION
This PR reverts the msgpack version restriction since the root cause of the original issue came from pandas-td, not td-client-python.  https://github.com/treasure-data/pandas-td/issues/14 