### PR TITLE
Ensure endpoint starts with 'https://' if scheme not given

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -33,11 +33,13 @@ from tdclient.schedule_api import ScheduleAPI
 from tdclient.server_status_api import ServerStatusAPI
 from tdclient.table_api import TableAPI
 from tdclient.user_api import UserAPI
-from tdclient.util import normalized_msgpack
-from tdclient.util import csv_dict_record_reader
-from tdclient.util import csv_text_record_reader
-from tdclient.util import read_csv_records
-from tdclient.util import validate_record
+from tdclient.util import (
+    csv_dict_record_reader,
+    csv_text_record_reader,
+    normalized_msgpack,
+    read_csv_records,
+    validate_record,
+)
 
 try:
     import certifi
@@ -107,6 +109,8 @@ class API(
             self._user_agent = "TD-Client-Python/%s" % (version.__version__)
 
         if endpoint is not None:
+            if not urlparse.urlparse(endpoint).scheme:
+                endpoint = "https://{}".format(endpoint)
             self._endpoint = endpoint
         elif os.getenv("TD_API_SERVER"):
             self._endpoint = os.getenv("TD_API_SERVER")

--- a/tdclient/test/api_test.py
+++ b/tdclient/test/api_test.py
@@ -98,6 +98,13 @@ def test_https_endpoint_with_custom_path():
     assert "https://api.example.com/v1/" == url
 
 
+def test_https_endpoint():
+    td = api.API("apikey", endpoint="api.example.com")
+    assert isinstance(td.http, urllib3.PoolManager)
+    url, headers = td.build_request()
+    assert "https://api.example.com" == url
+
+
 def test_http_proxy_from_environ():
     os.environ["HTTP_PROXY"] = "proxy1.example.com:8080"
     td = api.API("apikey")


### PR DESCRIPTION
If a user doesn't give a scheme for an endpoint, `http` will be used, e.g., `api.ap02.treasuredata.com` treated as `http://api.ap02.treasuredata.com`. This doesn't work new endpoints, i.e., ap02, since ap02 allows `https` only.

This patch ensures to use `https` if the scheme not given with endpoint.