### PR TITLE
Fix urls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Listing jobs
 
 Treasure Data API key will be read from environment variable ``TD_API_KEY``\ , if none is given via ``apikey=`` argument passed to ``tdclient.Client``.
 
-Treasure Data API endpoint ``https://api.treasuredata.com`` is used by default. You can override this with environment variable ``TD_API_SERVER``\ , which in turn can be overridden via ``endpoint=`` argument passed to ``tdclient.Client``. List of available Treasure Data sites and corresponding API endpoints can be found `here <https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints>`_.
+Treasure Data API endpoint ``https://api.treasuredata.com`` is used by default. You can override this with environment variable ``TD_API_SERVER``\ , which in turn can be overridden via ``endpoint=`` argument passed to ``tdclient.Client``. List of available Treasure Data sites and corresponding API endpoints can be found `here <https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints>`_.
 
 .. code-block:: python
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -614,7 +614,7 @@ class Client:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://support.treasuredata.com/hc/en-us/articles/360001451088-Scheduled-Jobs-Web-Console
+                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0
@@ -682,7 +682,7 @@ class Client:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://support.treasuredata.com/hc/en-us/articles/360001451088-Scheduled-Jobs-Web-Console
+                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -620,7 +620,7 @@ class Client:
                      before running the query. Default: 0
                 - query (str):
                      Is a language used to retrieve, insert, update and modify
-                     data. See also: https://support.treasuredata.com/hc/en-us/articles/360012069493-SQL-Examples-of-Scheduled-Queries
+                     data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                      Priority of the query.
                      Range is from -2 (very low) to 2 (very high). Default: 0
@@ -688,7 +688,7 @@ class Client:
                      before running the query. Default: 0
                 - query (str):
                      Is a language used to retrieve, insert, update and modify
-                     data. See also: https://support.treasuredata.com/hc/en-us/articles/360012069493-SQL-Examples-of-Scheduled-Queries
+                     data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                      Priority of the query.
                      Range is from -2 (very low) to 2 (very high). Default: 0

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -156,7 +156,7 @@ class ConnectorAPI:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://support.treasuredata.com/hc/en-us/articles/360001451088-Scheduled-Jobs-Web-Console
+                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -25,7 +25,7 @@ class ScheduleAPI:
                 - cron (str, optional):
                     Schedule of the query.
                     {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                    See also: https://support.treasuredata.com/hc/en-us/articles/360001451088-Scheduled-Jobs-Web-Console
+                    See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                     A delay ensures all buffered events are imported
                     before running the query. Default: 0

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -31,7 +31,7 @@ class ScheduleAPI:
                     before running the query. Default: 0
                 - query (str):
                     Is a language used to retrieve, insert, update and modify
-                    data. See also: https://support.treasuredata.com/hc/en-us/articles/360012069493-SQL-Examples-of-Scheduled-Queries
+                    data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                     Priority of the query.
                     Range is from -2 (very low) to 2 (very high). Default: 0
@@ -113,7 +113,7 @@ class ScheduleAPI:
                     before running the query. Default: 0
                 - query (str):
                     Is a language used to retrieve, insert, update and modify
-                    data. See also: https://support.treasuredata.com/hc/en-us/articles/360012069493-SQL-Examples-of-Scheduled-Queries
+                    data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                     Priority of the query.
                     Range is from -2 (very low) to 2 (very high). Default: 0


### PR DESCRIPTION
I found `https://support.treasuredata.com` URLs on README and comments.
I replaced them with new URLs starting with `https://tddocs.atlassian.net`.