### PR TITLE
Update documentation URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ It'd be better to install `certifi <https://pypi.python.org/pypi/certifi>`_ to e
 Examples
 --------
 
-Please see also the examples at `Treasure Data Documentation <http://docs.treasuredata.com/articles/rest-api-python-client>`_.
+Please see also the examples at `Treasure Data Documentation <https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081648/Python+Client+for+REST+API>`_.
 
 The td-client documentation is hosted at https://tdclient.readthedocs.io/,
 or you can go directly to the

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -107,7 +107,7 @@ class ScheduleAPI:
                 - cron (str, optional):
                     Schedule of the query.
                     {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                    See also: https://support.treasuredata.com/hc/en-us/articles/360001451088-Scheduled-Jobs-Web-Console
+                    See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                     A delay ensures all buffered events are imported
                     before running the query. Default: 0


### PR DESCRIPTION
I replaced Treasure Data older document URL since theses can't redirect correctly.