### PR TITLE
Fix typo/misspelled words in docstrings etc.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -191,7 +191,7 @@ v0.1.10 (2015-03-30)
 --------------------
 
 
-* Fixed a JSON parse error in ``job.result_format("json")`` with multipe result rows (#4)
+* Fixed a JSON parse error in ``job.result_format("json")`` with multiple result rows (#4)
 * Refactored model classes and tests
 
 v0.1.9 (2015-02-26)

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Treasure Data API library for Python
 
 .. image:: https://github.com/treasure-data/td-client-python/workflows/Python%20testing/badge.svg
    :target: https://github.com/treasure-data/td-client-python/actions
-   :alt: Build Status on GitHub ACtions
+   :alt: Build Status on GitHub Actions
 
 
 .. image:: https://ci.appveyor.com/api/projects/status/eol91l1ag50xee9m/branch/master?svg=true

--- a/tdclient/bulk_import_api.py
+++ b/tdclient/bulk_import_api.py
@@ -99,7 +99,7 @@ class BulkImportAPI:
 
         Args:
             name (str): Name of bulk import.
-            params (dict, optional): Extra parameteres.
+            params (dict, optional): Extra parameters.
         Returns:
             [str]: The list of bulk import part name.
         """
@@ -180,7 +180,7 @@ class BulkImportAPI:
           will be used, NOT the datatype.
 
         * ``converters`` is a dictionary used to specify a function that will
-          be used to parse individual columns, for instace ``{"col1", int}``.
+          be used to parse individual columns, for instance ``{"col1", int}``.
 
         The default behaviour is ``"guess"``, which makes a best-effort to decide
         the column datatype. See `file import parameters`_ for more details.

--- a/tdclient/bulk_import_model.py
+++ b/tdclient/bulk_import_model.py
@@ -197,7 +197,7 @@ class BulkImport(Model):
           will be used, NOT the datatype.
 
         * ``converters`` is a dictionary used to specify a function that will
-          be used to parse individual columns, for instace ``{"col1", int}``.
+          be used to parse individual columns, for instance ``{"col1", int}``.
 
         The default behaviour is ``"guess"``, which makes a best-effort to decide
         the column datatype. See `file import parameters`_ for more details.

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -564,7 +564,7 @@ class Client:
           will be used, NOT the datatype.
 
         * ``converters`` is a dictionary used to specify a function that will
-          be used to parse individual columns, for instace ``{"col1", int}``.
+          be used to parse individual columns, for instance ``{"col1", int}``.
 
         The default behaviour is ``"guess"``, which makes a best-effort to decide
         the column datatype. See `file import parameters`_ for more details.
@@ -670,7 +670,7 @@ class Client:
 
         Args:
             name (str): Target scheduled query name.
-            params (dict): Extra parameteres.
+            params (dict): Extra parameters.
 
                 - type (str):
                      Query type. {"presto", "hive"}. Default: "hive"

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -161,7 +161,7 @@ class ConnectorAPI:
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0
                 - database (str):
-                     Target databse for the Data Connector session
+                     Target database for the Data Connector session
                 - name (str):
                      Name of the Data Connector session
                 - table (str):

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -95,7 +95,7 @@ class ScheduleAPI:
 
         Args:
             name (str): Target scheduled query name.
-            params (dict): Extra parameteres.
+            params (dict): Extra parameters.
 
                 - type (str):
                     Query type. {"presto", "hive"}. Default: "hive"


### PR DESCRIPTION
This pull request fixes a few typo/misspellings. While reading the source code, I found these errors (PyCharm's editor helped me a lot).