### PR TITLE
Renew Treasure Data doc URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Listing jobs
 
 Treasure Data API key will be read from environment variable ``TD_API_KEY``\ , if none is given via ``apikey=`` argument passed to ``tdclient.Client``.
 
-Treasure Data API endpoint ``https://api.treasuredata.com`` is used by default. You can override this with environment variable ``TD_API_SERVER``\ , which in turn can be overridden via ``endpoint=`` argument passed to ``tdclient.Client``. List of available Treasure Data sites and corresponding API endpoints can be found `here <https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints>`_.
+Treasure Data API endpoint ``https://api.treasuredata.com`` is used by default. You can override this with environment variable ``TD_API_SERVER``\ , which in turn can be overridden via ``endpoint=`` argument passed to ``tdclient.Client``. List of available Treasure Data sites and corresponding API endpoints can be found `here <https://docs.treasuredata.com/display/PD/Sites+and+Endpoints>`_.
 
 .. code-block:: python
 

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -614,13 +614,13 @@ class Client:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
+                     See also: https://docs.treasuredata.com/display/PD/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0
                 - query (str):
                      Is a language used to retrieve, insert, update and modify
-                     data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
+                     data. See also: https://docs.treasuredata.com/display/PD/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                      Priority of the query.
                      Range is from -2 (very low) to 2 (very high). Default: 0
@@ -682,13 +682,13 @@ class Client:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
+                     See also: https://docs.treasuredata.com/display/PD/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0
                 - query (str):
                      Is a language used to retrieve, insert, update and modify
-                     data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
+                     data. See also: https://docs.treasuredata.com/display/PD/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                      Priority of the query.
                      Range is from -2 (very low) to 2 (very high). Default: 0

--- a/tdclient/connector_api.py
+++ b/tdclient/connector_api.py
@@ -156,7 +156,7 @@ class ConnectorAPI:
                 - cron (str, optional):
                      Schedule of the query.
                      {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                     See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
+                     See also: https://docs.treasuredata.com/display/PD/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                      A delay ensures all buffered events are imported
                      before running the query. Default: 0

--- a/tdclient/schedule_api.py
+++ b/tdclient/schedule_api.py
@@ -25,13 +25,13 @@ class ScheduleAPI:
                 - cron (str, optional):
                     Schedule of the query.
                     {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                    See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
+                    See also: https://docs.treasuredata.com/display/PD/Scheduling+Jobs+Using+TD+Console
                 - delay (int, optional):
                     A delay ensures all buffered events are imported
                     before running the query. Default: 0
                 - query (str):
                     Is a language used to retrieve, insert, update and modify
-                    data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
+                    data. See also: https://docs.treasuredata.com/display/PD/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                     Priority of the query.
                     Range is from -2 (very low) to 2 (very high). Default: 0
@@ -107,13 +107,13 @@ class ScheduleAPI:
                 - cron (str, optional):
                     Schedule of the query.
                     {``"@daily"``, ``"@hourly"``, ``"10 * * * *"`` (custom cron)}
-                    See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084633/Scheduling+Jobs+Using+TD+Console
+                    See also: https://docs.treasuredata.com/display/PD/Schedling+Jobs+Using+TD+Console
                 - delay (int, optional):
                     A delay ensures all buffered events are imported
                     before running the query. Default: 0
                 - query (str):
                     Is a language used to retrieve, insert, update and modify
-                    data. See also: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084438/SQL+Examples+of+Scheduled+Queries
+                    data. See also: https://docs.treasuredata.com/display/PD/SQL+Examples+of+Scheduled+Queries
                 - priority (int, optional):
                     Priority of the query.
                     Range is from -2 (very low) to 2 (very high). Default: 0


### PR DESCRIPTION
This library shows old doc URL. Since the URL is no longer accessible, renewed the URL.