### PR TITLE
Add header parameter and fix bug

### DIFF
--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -323,7 +323,7 @@ class Client:
         for row in self.api.job_result_each(job_id):
             yield row
 
-    def job_result_format(self, job_id, format):
+    def job_result_format(self, job_id, format, header=False):
         """
         Args:
             job_id (str): job id
@@ -332,9 +332,9 @@ class Client:
         Returns:
              a list of each rows in result set
         """
-        return self.api.job_result_format(job_id, format)
+        return self.api.job_result_format(job_id, format, header=header)
 
-    def job_result_format_each(self, job_id, format):
+    def job_result_format_each(self, job_id, format, header=False):
         """
         Args:
             job_id (str): job id
@@ -343,7 +343,7 @@ class Client:
         Returns:
              an iterator of rows in result set
         """
-        for row in self.api.job_result_format_each(job_id, format):
+        for row in self.api.job_result_format_each(job_id, format, header=header):
             yield row
 
     def kill(self, job_id):
@@ -568,7 +568,7 @@ class Client:
 
         The default behaviour is ``"guess"``, which makes a best-effort to decide
         the column datatype. See `file import parameters`_ for more details.
-        
+
         .. _`file import parameters`:
            https://tdclient.readthedocs.io/en/latest/file_import_parameters.html
         """

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -201,34 +201,48 @@ class JobAPI:
         for row in self.job_result_format_each(job_id, "msgpack"):
             yield row
 
-    def job_result_format(self, job_id, format):
+    def job_result_format(self, job_id, format, header=False):
         """Return the job result with specified format.
 
         Args:
             job_id (int): Job ID
             format (str): Output format of the job result information.
                 "json" or "msgpack"
+            header (boolean): Includes Header or not. 
+                False or True
 
         Returns:
              The query result of the specified job in.
         """
         result = []
-        for row in self.job_result_format_each(job_id, format):
+        for row in self.job_result_format_each(job_id, format, header):
             result.append(row)
         return result
 
-    def job_result_format_each(self, job_id, format):
+    def job_result_format_each(self, job_id, format, header=False):
         """Yield a row of the job result with specified format.
 
         Args:
             job_id (int): job ID
-            format (str): Output format of the job result information. "json" or "msgpack"
-
+            format (str): Output format of the job result information. 
+                "json" or "msgpack"
+            header (bool): Include Header info or not
+                "True" or "False"
         Yields:
              The query result of the specified job in.
         """
+
+        """
+        For backward compatibility, need to convert csv and tsv to json.
+        If csv/tsv is specified as it is, the result will be like this.
+            [b'num_col,null_col\n1,\n']
+        """
+        if format != "msgpack":
+            format = "json"
+
         with self.get(
-            create_url("/v3/job/result/{job_id}", job_id=job_id), {"format": format}
+            create_url("/v3/job/result/{job_id}?format={format}&header={header}",
+                       job_id=job_id, format=format, header=header)
         ) as res:
             code = res.status
             if code != 200:

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -273,7 +273,7 @@ def test_job_result_format():
     rows = [[123], [456]]
     td._api.job_result_format = mock.MagicMock(return_value=rows)
     result = td.job_result_format("12345", "json")
-    td.api.job_result_format.assert_called_with("12345", "json")
+    td.api.job_result_format.assert_called_with("12345", "json", header=False)
     assert result == rows
 
 
@@ -285,7 +285,7 @@ def test_job_result_format_each():
     result = []
     for row in td.job_result_format_each("12345", "json"):
         result.append(row)
-    td.api.job_result_format_each.assert_called_with("12345", "json")
+    td.api.job_result_format_each.assert_called_with("12345", "json", header=False)
     assert result == rows
 
 

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -140,7 +140,7 @@ def test_job_result_success():
         body += packer.pack(row)
     td.get = mock.MagicMock(return_value=make_response(200, body))
     result = td.job_result(12345)
-    td.get.assert_called_with("/v3/job/result/12345", {"format": "msgpack"})
+    td.get.assert_called_with("/v3/job/result/12345?format=msgpack&header=False")
     assert result == rows
 
 
@@ -155,7 +155,7 @@ def test_job_result_each_success():
     result = []
     for row in td.job_result_each(12345):
         result.append(row)
-    td.get.assert_called_with("/v3/job/result/12345", {"format": "msgpack"})
+    td.get.assert_called_with("/v3/job/result/12345?format=msgpack&header=False")
     assert result == rows
 
 
@@ -166,7 +166,18 @@ def test_job_result_json_success():
     body = "\n".join([json.dumps(row) for row in rows]).encode("utf-8")
     td.get = mock.MagicMock(return_value=make_response(200, body))
     result = td.job_result_format(12345, "json")
-    td.get.assert_called_with("/v3/job/result/12345", {"format": "json"})
+    td.get.assert_called_with("/v3/job/result/12345?format=json&header=False")
+    assert result == rows
+
+
+def test_job_result_json_with_header_success():
+    td = api.API("APIKEY")
+    rows = [["col1", "col2"], ["foo", 123], ["bar", 456], ["baz", 789]]
+    # result will be a JSON record per line (#4)
+    body = "\n".join([json.dumps(row) for row in rows]).encode("utf-8")
+    td.get = mock.MagicMock(return_value=make_response(200, body))
+    result = td.job_result_format(12345, "json", header=True)
+    td.get.assert_called_with("/v3/job/result/12345?format=json&header=True")
     assert result == rows
 
 
@@ -179,7 +190,20 @@ def test_job_result_json_each_success():
     result = []
     for row in td.job_result_format_each(12345, "json"):
         result.append(row)
-    td.get.assert_called_with("/v3/job/result/12345", {"format": "json"})
+    td.get.assert_called_with("/v3/job/result/12345?format=json&header=False")
+    assert result == rows
+
+
+def test_job_result_json_with_header_each_success():
+    td = api.API("APIKEY")
+    rows = [["col1", "col2"], ["foo", 123], ["bar", 456], ["baz", 789]]
+    # result will be a JSON record per line (#4)
+    body = "\n".join([json.dumps(row) for row in rows]).encode("utf-8")
+    td.get = mock.MagicMock(return_value=make_response(200, body))
+    result = []
+    for row in td.job_result_format_each(12345, "json", header=True):
+        result.append(row)
+    td.get.assert_called_with("/v3/job/result/12345?format=json&header=True")
     assert result == rows
 
 


### PR DESCRIPTION
# Purpose

The current implementation does not support header parameters of result download API even if it is supported by API.

https://api-docs.treasuredata.com/pages/td-api/tag/Jobs/#tag/Jobs/operation/getJobResults!in=query&path=header&t=request

# What would happen?

Users can download query results with header info.

Here is the sample and its result

```Python
#!/usr/bin/env python3

import tdclient
import os


apikey = os.getenv("TD_API_KEY")
client = tdclient.Client(apikey=apikey)

res = client.job_result_format(job_id=1615000898, format="tsv", header=True)
print(f"tsv: {res}")

res = client.job_result_format(job_id=1615000898, format="csv", header=True)
print(f"csv: {res}")

res = client.job_result_format(job_id=1615000898, format="msgpack", header=True)
print(f"msgpack: {res}")

res = client.job_result_format(job_id=1615000898, format="json", header=True)
print(f"json: {res}")

res = client.job_result_format(job_id=1615000898, format="tsv")
print(f"tsv: {res}")

res = client.job_result_format(job_id=1615000898, format="csv")
print(f"csv: {res}")

res = client.job_result_format(job_id=1615000898, format="msgpack")
print(f"msgpack: {res}")

res = client.job_result_format(job_id=1615000898, format="json")
print(f"json: {res}")
```

```bash
tsv: [['num_col', 'null_col'], [1, None]]
csv: [['num_col', 'null_col'], [1, None]]
msgpack: [[1, None]]
json: [['num_col', 'null_col'], [1, None]]
tsv: [[1, None]]
csv: [[1, None]]
msgpack: [[1, None]]
json: [[1, None]]
```