### PR TITLE
fix long_description_content_type for PEP 566 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     version=version,
     description="Treasure Data API library for Python",
     long_description=read("README.rst"),
-    long_description_content_type="text/x-rst; charset=UTF-8;",
+    long_description_content_type="text/x-rst; charset=UTF-8",
     author="Treasure Data, Inc.",
     author_email="support@treasure-data.com",
     url="http://treasuredata.com/",


### PR DESCRIPTION
the `long_description_content_type`  wasn't compliant with PEP 566, check [here](https://packaging.python.org/en/latest/specifications/core-metadata/#description-content-type) for the documentation. This seems to cause a failure when trying to download the library from a private azure devops feed setted up with pypi as upstream source. During the download raises a `HTTP error 400 Client Error: Bad Request - The package description content type is invalid. It should conform to the format described in PEP 566.` Compliance with PEP 566 has been broken since version 1.0.0, downloading in the same way the version 0.14.0 works correctly.