### PR TITLE
Fix: Handle "/" character in query names to prevent NotFoundError

### DIFF
--- a/tdclient/util.py
+++ b/tdclient/util.py
@@ -17,7 +17,7 @@ def create_url(tmpl, **values):
         tmpl (str): url template
         values (dict): values for url
     """
-    quoted_values = {k: urlquote(str(v)) for k, v in values.items()}
+    quoted_values = {k: urlquote(str(v), safe="") for k, v in values.items()}
     return tmpl.format(**quoted_values)
 
 


### PR DESCRIPTION
### Summary

This pull request fixes the NotFoundError that occurs when query names contain the "/" character.

### Details

As reported in the issue [#106](https://github.com/treasure-data/td-client-python/issues/106), query names with the "/" character were not being properly encoded, leading to an API endpoint not found error. The issue was due to the default behavior of the `urllib.parse.quote` function, which does not encode the "/" character.

### Fix

Updated the `create_url` function in `tdclient/util.py` as follows:
```diff
-    quoted_values = {k: urlquote(str(v)) for k, v in values.items()}
+    quoted_values = {k: urlquote(str(v), safe="") for k, v in values.items()}
```
This change ensures that all characters, including "/", are correctly encoded.

