### PR TITLE
Add download_job_result method to JobAPI

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -4,6 +4,7 @@ import contextlib
 import csv
 import email.utils
 import gzip
+import http
 import io
 import json
 import logging
@@ -13,7 +14,6 @@ import ssl
 import tempfile
 import time
 import urllib.parse as urlparse
-import warnings
 from array import array
 
 import msgpack
@@ -206,6 +206,8 @@ class API(
                 urllib3.exceptions.TimeoutStateError,
                 urllib3.exceptions.TimeoutError,
                 urllib3.exceptions.PoolError,
+                http.client.IncompleteRead,
+                TimeoutError,
                 socket.error,
             ):
                 pass
@@ -494,7 +496,6 @@ class API(
         return (url, _headers)
 
     def send_request(self, method, url, fields=None, body=None, headers=None, **kwargs):
-
         if body is None:
             return self.http.request(
                 method, url, fields=fields, headers=headers, **kwargs

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -346,16 +346,18 @@ class Client:
         for row in self.api.job_result_format_each(job_id, format, header=header):
             yield row
 
-    def download_job_result(self, job_id, path):
+    def download_job_result(self, job_id, path, num_threads=4):
         """Save the job result into a msgpack.gz file.
         Args:
             job_id (str): job id
             path (str): path to save the result
+            num_threads (int, optional): number of threads to download the result.
+                Default: 4
 
         Returns:
              `True` if success
         """
-        return self.api.download_job_result(job_id, path)
+        return self.api.download_job_result(job_id, path, num_threads=num_threads)
 
     def kill(self, job_id):
         """

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -346,6 +346,17 @@ class Client:
         for row in self.api.job_result_format_each(job_id, format, header=header):
             yield row
 
+    def download_job_result(self, job_id, path):
+        """Save the job result into a msgpack.gz file.
+        Args:
+            job_id (str): job id
+            path (str): path to save the result
+
+        Returns:
+             `True` if success
+        """
+        return self.api.download_job_result(job_id, path)
+
     def kill(self, job_id):
         """
         Args:

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -207,6 +207,49 @@ def test_job_result_json_with_header_each_success():
     assert result == rows
 
 
+def test_download_job_result():
+    td = api.API("APIKEY")
+    body = b"""
+        {
+            "cpu_time": null,
+            "created_at": "2015-02-09 11:44:25 UTC",
+            "database": "sample_datasets",
+            "debug": {
+                "cmdout": "started at 2015-02-09T11:44:27Z\\nexecuting query: SELECT COUNT(1) FROM nasdaq\\n",
+                "stderr": null
+            },
+            "duration": 1,
+            "end_at": "2015-02-09 11:44:28 UTC",
+            "hive_result_schema": "[[\\"cnt\\", \\"bigint\\"]]",
+            "job_id": "12345",
+            "organization": null,
+            "priority": 1,
+            "query": "SELECT COUNT(1) FROM nasdaq",
+            "result": "",
+            "result_size": 22,
+            "retry_limit": 0,
+            "start_at": "2015-02-09 11:44:27 UTC",
+            "status": "success",
+            "type": "presto",
+            "updated_at": "2015-02-09 11:44:28 UTC",
+            "url": "http://console.example.com/jobs/12345",
+            "user_name": "nobody@example.com",
+            "linked_result_export_job_id": null,
+            "result_export_target_job_id": null,
+            "num_records": 4
+        }
+    """
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value3", "int": 4, "float": 5.6},
+    ]
+    body_download = gzipb(msgpackb(data))
+    td.get = mock.MagicMock()
+    td.get.side_effect = [make_response(200, body), make_response(206, body_download)]
+    td.download_job_result(12345, "output.msgpack.gz")
+    td.get.assert_called_with("/v3/job/result/12345?format=msgpack.gz", headers={'Range': 'bytes=0-21'})
+
+
 def test_kill_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -46,7 +46,11 @@ def make_raw_response(status, body, headers={}):
         else:
             return b""
 
+    def stream(size=None):
+        yield read(size)
+
     response.read.side_effect = read
+    response.stream.side_effect = stream
     return response
 
 


### PR DESCRIPTION
This method downloads the result of a job to a
local file in msgpack.gz format. It can specify
thread number for parallel download.

## File validation

Confirmed that checksum is the same as a downloaded file by TD toolbelt.

```sh
$ shasum 2172017217*
5e227ef6582fd216ce1f0d8b81d43a4a6274aff6  2172017217.msgpack.gz
5e227ef6582fd216ce1f0d8b81d43a4a6274aff6  2172017217_toolbelt.msgpack.gz
```

## Download speed comparison 

- TD Toolbelt: 37 mins (including one retry)
- td-client-python with 6 threads: 4 mins


```sh
$ time /Users/ariga/.gem/ruby/2.6.0/bin/td job:show 2172017217 -f msgpack.gz -o 2172017217_toolbelt.msgpack.gz
JobID       : 2172017217
Status      : success
Type        : presto
Database    : aki_audience_large
Start At    : 2024-08-17 08:52:04 UTC
End At      : 2024-08-17 09:03:29 UTC
Priority    : NORMAL
Retry limit : 0
Output      :
Query       : select * from behavior_1 limit 100_000_000
Result size : 2.84 GB
Result      :
EOFError: httpclient IncompleteError. Retrying after 5 seconds...ack.gz in msgpack.gz format 966.9 MB /  2.8 GB : ======= 33 ========
NOTE: the job result is being written to 2172017217_toolbelt.msgpack.gz in msgpack.gz format  2.8 GB /  2.8 GB : =========================== 100 ===========================
written to 2172017217_toolbelt.msgpack.gz in msgpack.gz format
Use '-v' option to show detailed messages.
/Users/ariga/.gem/ruby/2.6.0/bin/td job:show 2172017217 -f msgpack.gz -o   71.05s user 62.49s system 5% cpu 37:38.02 total
```

```py
>>> import tdclient; import os; td = tdclient.Client(apikey=os.environ["TD_API_KEY"])
>>> import time; s = time.time(); td.download_job_result("2172017217", "2172017217.msgpack.gz"); print(f"elapsed time: {time.time() - s} sec")
True
elapsed time: 240.56217789649963 sec
```