### PR TITLE
Add store_tmpfile option to job_result_format_each() method to JobAPI and Client

### DIFF
--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -93,7 +93,7 @@ class API(
         retry_post_requests=False,
         max_cumul_retry_delay=600,
         http_proxy=None,
-        **kwargs
+        **kwargs,
     ):
         headers = {} if headers is None else headers
         if apikey is not None:
@@ -599,7 +599,7 @@ class API(
         encoding="utf-8",
         dtypes=None,
         converters=None,
-        **kwargs
+        **kwargs,
     ):
         if columns is None:
             reader = csv_dict_record_reader(file_like, encoding, dialect)

--- a/tdclient/api.py
+++ b/tdclient/api.py
@@ -4,6 +4,7 @@ import contextlib
 import csv
 import email.utils
 import gzip
+import http
 import io
 import json
 import logging
@@ -13,7 +14,6 @@ import ssl
 import tempfile
 import time
 import urllib.parse as urlparse
-import warnings
 from array import array
 
 import msgpack
@@ -206,6 +206,8 @@ class API(
                 urllib3.exceptions.TimeoutStateError,
                 urllib3.exceptions.TimeoutError,
                 urllib3.exceptions.PoolError,
+                http.client.IncompleteRead,
+                TimeoutError,
                 socket.error,
             ):
                 pass
@@ -494,7 +496,6 @@ class API(
         return (url, _headers)
 
     def send_request(self, method, url, fields=None, body=None, headers=None, **kwargs):
-
         if body is None:
             return self.http.request(
                 method, url, fields=fields, headers=headers, **kwargs

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -346,16 +346,18 @@ class Client:
         for row in self.api.job_result_format_each(job_id, format, header=header):
             yield row
 
-    def download_job_result(self, job_id, path):
+    def download_job_result(self, job_id, path, num_threads=4):
         """Save the job result into a msgpack.gz file.
         Args:
             job_id (str): job id
             path (str): path to save the result
+            num_threads (int, optional): number of threads to download the result.
+                Default: 4
 
         Returns:
              `True` if success
         """
-        return self.api.download_job_result(job_id, path)
+        return self.api.download_job_result(job_id, path, num_threads=num_threads)
 
     def kill(self, job_id):
         """

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -346,6 +346,17 @@ class Client:
         for row in self.api.job_result_format_each(job_id, format, header=header):
             yield row
 
+    def download_job_result(self, job_id, path):
+        """Save the job result into a msgpack.gz file.
+        Args:
+            job_id (str): job id
+            path (str): path to save the result
+
+        Returns:
+             `True` if success
+        """
+        return self.api.download_job_result(job_id, path)
+
     def kill(self, job_id):
         """
         Args:

--- a/tdclient/client.py
+++ b/tdclient/client.py
@@ -6,8 +6,7 @@ from tdclient import api, models
 
 
 class Client:
-    """API Client for Treasure Data Service
-    """
+    """API Client for Treasure Data Service"""
 
     def __init__(self, *args, **kwargs):
         self._api = api.API(*args, **kwargs)
@@ -79,7 +78,7 @@ class Client:
              :class:`tdclient.models.Database`
         """
         databases = self.api.list_databases()
-        for (name, kwargs) in databases.items():
+        for name, kwargs in databases.items():
             if name == db_name:
                 return models.Database(self, name, **kwargs)
         raise api.NotFoundError("Database '%s' does not exist" % (db_name))
@@ -229,7 +228,7 @@ class Client:
         priority=None,
         retry_limit=None,
         type="hive",
-        **kwargs
+        **kwargs,
     ):
         """Run a query on specified database table.
 
@@ -258,7 +257,7 @@ class Client:
             result_url=result_url,
             priority=priority,
             retry_limit=retry_limit,
-            **kwargs
+            **kwargs,
         )
         return models.Job(self, job_id, type, q)
 
@@ -334,16 +333,30 @@ class Client:
         """
         return self.api.job_result_format(job_id, format, header=header)
 
-    def job_result_format_each(self, job_id, format, header=False):
+    def job_result_format_each(
+        self, job_id, format, header=False, store_tmpfile=False, num_threads=4
+    ):
         """
         Args:
             job_id (str): job id
             format (str): output format of result set
+            header (bool, optional): include header in the result set. Default: False
+            store_tmpfile (bool, optional): store result to a temporary file.
+                Works only when fmt is "msgpack". Default is False.
+            num_threads (int, optional): number of threads to download result.
+                Works only when store_tmpfile is True. Default is 4.
+
 
         Returns:
              an iterator of rows in result set
         """
-        for row in self.api.job_result_format_each(job_id, format, header=header):
+        for row in self.api.job_result_format_each(
+            job_id,
+            format,
+            header=header,
+            store_tmpfile=store_tmpfile,
+            num_threads=num_threads,
+        ):
             yield row
 
     def download_job_result(self, job_id, path, num_threads=4):
@@ -940,8 +953,7 @@ class Client:
         return self.api.remove_apikey(name, apikey)
 
     def close(self):
-        """Close opened API connections.
-        """
+        """Close opened API connections."""
         return self._api.close()
 
 

--- a/tdclient/job_api.py
+++ b/tdclient/job_api.py
@@ -254,9 +254,11 @@ class JobAPI:
             if code != 200:
                 self.raise_error("Get job result failed", res, "")
             if format == "msgpack":
-                unpacker = msgpack.Unpacker(res, raw=False)
-                for row in unpacker:
-                    yield row
+                unpacker = msgpack.Unpacker(raw=False, max_buffer_size=1000 * 1024 ** 2)
+                for chunk in res.stream(1024 ** 2):
+                    unpacker.feed(chunk)
+                    for row in unpacker:
+                        yield row
             elif format == "json":
                 for row in codecs.getreader("utf-8")(res):
                     yield json.loads(row)

--- a/tdclient/job_model.py
+++ b/tdclient/job_model.py
@@ -7,8 +7,7 @@ from tdclient.model import Model
 
 
 class Schema:
-    """Schema of a database table on Treasure Data Service
-    """
+    """Schema of a database table on Treasure Data Service"""
 
     class Field:
         def __init__(self, name, type):
@@ -48,8 +47,7 @@ class Schema:
 
 
 class Job(Model):
-    """Job on Treasure Data Service
-    """
+    """Job on Treasure Data Service"""
 
     STATUS_QUEUED = "queued"
     STATUS_BOOTING = "booting"
@@ -92,8 +90,7 @@ class Job(Model):
         self._result_export_target_job_id = data.get("result_export_target_job_id")
 
     def update(self):
-        """Update all fields of the job
-        """
+        """Update all fields of the job"""
         data = self._client.api.show_job(self._job_id)
         self._feed(data)
 
@@ -105,57 +102,48 @@ class Job(Model):
         self.update()
 
     def _update_progress(self):
-        """Update `_status` field of the job if it's not finished
-        """
+        """Update `_status` field of the job if it's not finished"""
         if self._status not in self.FINISHED_STATUS:
             self._status = self._client.job_status(self._job_id)
 
     @property
     def id(self):
-        """a string represents the identifier of the job
-        """
+        """a string represents the identifier of the job"""
         return self._job_id
 
     @property
     def job_id(self):
-        """a string represents the identifier of the job
-        """
+        """a string represents the identifier of the job"""
         return self._job_id
 
     @property
     def type(self):
-        """a string represents the engine type of the job (e.g. "hive", "presto", etc.)
-        """
+        """a string represents the engine type of the job (e.g. "hive", "presto", etc.)"""
         return self._type
 
     @property
     def result_size(self):
-        """the length of job result
-        """
+        """the length of job result"""
         return self._result_size
 
     @property
     def num_records(self):
-        """the number of records of job result
-        """
+        """the number of records of job result"""
         return self._num_records
 
     @property
     def result_url(self):
-        """a string of URL of the result on Treasure Data Service
-        """
+        """a string of URL of the result on Treasure Data Service"""
         return self._result_url
 
     @property
     def result_schema(self):
-        """an array of array represents the type of result columns (Hive specific) (e.g. [["_c1", "string"], ["_c2", "bigint"]])
-        """
+        """an array of array represents the type of result columns (Hive specific) (e.g. [["_c1", "string"], ["_c2", "bigint"]])"""
         return self._hive_result_schema
 
     @property
     def priority(self):
-        """a string represents the priority of the job (e.g. "NORMAL", "HIGH", etc.)
-        """
+        """a string represents the priority of the job (e.g. "NORMAL", "HIGH", etc.)"""
         if self._priority in self.JOB_PRIORITY:
             return self.JOB_PRIORITY[self._priority]
         else:
@@ -164,44 +152,37 @@ class Job(Model):
 
     @property
     def retry_limit(self):
-        """a number for automatic retry count
-        """
+        """a number for automatic retry count"""
         return self._retry_limit
 
     @property
     def org_name(self):
-        """organization name
-        """
+        """organization name"""
         return self._org_name
 
     @property
     def user_name(self):
-        """executing user name
-        """
+        """executing user name"""
         return self._user_name
 
     @property
     def database(self):
-        """a string represents the name of a database that job is running on
-        """
+        """a string represents the name of a database that job is running on"""
         return self._database
 
     @property
     def linked_result_export_job_id(self):
-        """Linked result export job ID from query job
-        """
+        """Linked result export job ID from query job"""
         return self._linked_result_export_job_id
 
     @property
     def result_export_target_job_id(self):
-        """Associated query job ID from result export job ID
-        """
+        """Associated query job ID from result export job ID"""
         return self._result_export_target_job_id
 
     @property
     def debug(self):
-        """a :class:`dict` of debug output (e.g. "cmdout", "stderr")
-        """
+        """a :class:`dict` of debug output (e.g. "cmdout", "stderr")"""
         return self._debug
 
     def wait(self, timeout=None, wait_interval=5, wait_callback=None):
@@ -235,8 +216,7 @@ class Job(Model):
 
     @property
     def query(self):
-        """a string represents the query string of the job
-        """
+        """a string represents the query string of the job"""
         return self._query
 
     def status(self):
@@ -250,8 +230,7 @@ class Job(Model):
 
     @property
     def url(self):
-        """a string of URL of the job on Treasure Data Service
-        """
+        """a string of URL of the job on Treasure Data Service"""
         return self._url
 
     def result(self):
@@ -270,10 +249,14 @@ class Job(Model):
                 for row in self._result:
                     yield row
 
-    def result_format(self, fmt):
+    def result_format(self, fmt, store_tmpfile=False, num_threads=4):
         """
         Args:
             fmt (str): output format of result set
+            store_tmpfile (bool, optional): store result to a temporary file.
+                Works only when fmt is "msgpack". Default is False.
+            num_threads (int, optional): number of threads to download result.
+                Works only when store_tmpfile is True. Default is 4.
 
         Yields:
              an iterator of rows in result set
@@ -283,7 +266,12 @@ class Job(Model):
         else:
             self.update()
             if self._result is None:
-                for row in self._client.job_result_format_each(self._job_id, fmt):
+                for row in self._client.job_result_format_each(
+                    self._job_id,
+                    fmt,
+                    store_tmpfile=store_tmpfile,
+                    num_threads=num_threads,
+                ):
                     yield row
             else:
                 for row in self._result:

--- a/tdclient/test/client_test.py
+++ b/tdclient/test/client_test.py
@@ -285,7 +285,9 @@ def test_job_result_format_each():
     result = []
     for row in td.job_result_format_each("12345", "json"):
         result.append(row)
-    td.api.job_result_format_each.assert_called_with("12345", "json", header=False)
+    td.api.job_result_format_each.assert_called_with(
+        "12345", "json", header=False, store_tmpfile=False, num_threads=4
+    )
     assert result == rows
 
 

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -209,6 +209,54 @@ def test_job_result_json_with_header_each_success():
     assert result == rows
 
 
+def test_job_result_msgpack_each_store_tmpfile_success():
+    td = api.API("APIKEY")
+    body = b"""
+        {
+            "cpu_time": null,
+            "created_at": "2015-02-09 11:44:25 UTC",
+            "database": "sample_datasets",
+            "debug": {
+                "cmdout": "started at 2015-02-09T11:44:27Z\\nexecuting query: SELECT COUNT(1) FROM nasdaq\\n",
+                "stderr": null
+            },
+            "duration": 1,
+            "end_at": "2015-02-09 11:44:28 UTC",
+            "hive_result_schema": "[[\\"cnt\\", \\"bigint\\"]]",
+            "job_id": "12345",
+            "organization": null,
+            "priority": 1,
+            "query": "SELECT COUNT(1) FROM nasdaq",
+            "result": "",
+            "result_size": 22,
+            "retry_limit": 0,
+            "start_at": "2015-02-09 11:44:27 UTC",
+            "status": "success",
+            "type": "presto",
+            "updated_at": "2015-02-09 11:44:28 UTC",
+            "url": "http://console.example.com/jobs/12345",
+            "user_name": "nobody@example.com",
+            "linked_result_export_job_id": null,
+            "result_export_target_job_id": null,
+            "num_records": 4
+        }
+    """
+    rows = [["foo", 123], ["bar", 456], ["baz", 789]]
+    body_download = gzipb(msgpackb(rows))
+    td.get = mock.MagicMock()
+    td.get.side_effect = [
+        make_response(200, body),
+        make_response(206, body_download),
+    ]
+    result = []
+    for row in td.job_result_format_each(12345, "msgpack", store_tmpfile=True):
+        result.append(row)
+    td.get.assert_called_with(
+        "/v3/job/result/12345?format=msgpack.gz", headers={"Range": "bytes=0-21"}
+    )
+    assert result == rows
+
+
 def test_download_job_result():
     td = api.API("APIKEY")
     body = b"""
@@ -252,10 +300,13 @@ def test_download_job_result():
         temp = os.path.join(tempdir, str(uuid.uuid4()))
         td.download_job_result(12345, temp)
         td.get.assert_any_call("/v3/job/show/12345")
-        td.get.assert_any_call("/v3/job/result/12345?format=msgpack.gz", headers={'Range': 'bytes=0-21'})
+        td.get.assert_any_call(
+            "/v3/job/result/12345?format=msgpack.gz", headers={"Range": "bytes=0-21"}
+        )
         with open(temp, "rb") as f:
             result = msgunpackb(gunzipb(f.read()))
             assert result == data
+
 
 def test_kill_success():
     td = api.API("APIKEY")

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -207,6 +207,49 @@ def test_job_result_json_with_header_each_success():
     assert result == rows
 
 
+def test_download_job_result():
+    td = api.API("APIKEY")
+    body = b"""
+        {
+            "cpu_time": null,
+            "created_at": "2015-02-09 11:44:25 UTC",
+            "database": "sample_datasets",
+            "debug": {
+                "cmdout": "started at 2015-02-09T11:44:27Z\\nexecuting query: SELECT COUNT(1) FROM nasdaq\\n",
+                "stderr": null
+            },
+            "duration": 1,
+            "end_at": "2015-02-09 11:44:28 UTC",
+            "hive_result_schema": "[[\\"cnt\\", \\"bigint\\"]]",
+            "job_id": "12345",
+            "organization": null,
+            "priority": 1,
+            "query": "SELECT COUNT(1) FROM nasdaq",
+            "result": "",
+            "result_size": 22,
+            "retry_limit": 0,
+            "start_at": "2015-02-09 11:44:27 UTC",
+            "status": "success",
+            "type": "presto",
+            "updated_at": "2015-02-09 11:44:28 UTC",
+            "url": "http://console.example.com/jobs/12345",
+            "user_name": "nobody@example.com",
+            "linked_result_export_job_id": null,
+            "result_export_target_job_id": null,
+            "num_records": 4
+        }
+    """
+    data = [
+        {"str": "value1", "int": 1, "float": 2.3},
+        {"str": "value3", "int": 4, "float": 5.6},
+    ]
+    body_download = gzipb(msgpackb(data))
+    td.get = mock.MagicMock()
+    td.get.side_effect = [make_response(200, body), make_response(206, body_download)]
+    td.download_job_result(12345, "output.msgpack.gz")
+    td.get.assert_called_with("/v3/job/result/12345?format=msgpack.gz", headers={'Range': 'bytes=0-21'})
+
+
 def test_kill_success():
     td = api.API("APIKEY")
     # TODO: should be replaced by wire dump

--- a/tdclient/test/job_model_test.py
+++ b/tdclient/test/job_model_test.py
@@ -176,7 +176,7 @@ def test_job_result_failure():
 def test_job_result_format_generator():
     client = mock.MagicMock()
 
-    def job_result_format_each(job_id, format):
+    def job_result_format_each(job_id, format, store_tmpfile=False, num_threads=1):
         assert job_id == "12345"
         assert format == "msgpack.gz"
         yield ["foo", 123]

--- a/tdclient/test/test_helper.py
+++ b/tdclient/test/test_helper.py
@@ -46,7 +46,11 @@ def make_raw_response(status, body, headers={}):
         else:
             return b""
 
+    def stream(size=None):
+        yield read(size)
+
     response.read.side_effect = read
+    response.stream.side_effect = stream
     return response
 
 


### PR DESCRIPTION
This PR depends on  #118 and #119. Please merge after them.

The main contribution is [69bb7e9](https://github.com/treasure-data/td-client-python/pull/120/commits/69bb7e924bfbd06e8d9f8b1498107169a44d162d)

This patch allows the download of large query results in parallel.

The following evaluation shows iteration over 1GiB query result speeds up 8 times.

### With `store_tmpfile=True`

```py
>>> import time; s = time.time(); len(list(td.api.job_result_format_each("2172739824", "msgpack", store_tmpfile=True, num_threads=6))); print(f"elapsed time: {time.time() - s} sec")
33000000
elapsed time: 208.30903315544128 sec
```

### With `store_tmpfile=False` (same as previous)

```py
>>> import tdclient; import os; td = tdclient.Client(apikey=os.environ["TD_API_KEY"])
>>> import time; s = time.time(); len(list(td.api.job_result_format_each("2172739824", "msgpack", store_tmpfile=False))); print(f"elapsed time: {time.time() - s} sec")
33000000
elapsed time: 1850.3040738105774 sec

