### PR TITLE
Update build step of python-publish script

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,5 +24,5 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*


### PR DESCRIPTION
Due to adoption of pyproject.toml instead of setup.py: https://github.com/treasure-data/td-client-python/pull/122, we need to update python-publish script