### PR TITLE
Release 1.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,8 +293,10 @@ Then, run ``tox``.
 Release
 ^^^^^^^
 
-Create and push a tag to GitHub, then creating a Release on GitHub will publish new version to PyPI.
-
+1. Update version `x.x.x` in `pyproject.toml`.
+2. Create a PR with `release-x.x.x` branch. Request and merge the PR.
+3. Create and push a tag `x.x.x` on `release-x.x.x` merge commit.
+4. Create a Release on GitHub will publish new version to PyPI.
 
 Manual release
 ~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "td-client"
-version = "1.2.2.dev0"
+version = "1.3.0"
 description = "Treasure Data API library for Python"
 readme = {file = "README.rst", content-type = "text/x-rst; charset=UTF-8"}
 requires-python = ">=3.8"


### PR DESCRIPTION
### Change logs

- Support Python from 3.8 to 3.12.
- [Internal] Use `Unpacker.feed` to download msgpack data.
- New `download_job_result` API to download the job result to local msgpack file.
- Support download job result to local file with new `store_tmpfile` (bool, optional) and `num_threads` (int, optional) parameters in `job_result_format_each` API.
- Support fetching header info with new headers parameter in `job_result_format_each` and `job_result_format_each` APIs.
- Various docstring updates.