### PR TITLE
[JobAPI] Multithreaded Temporary File Storage: Replace `gzip` with `open()`

### DIFF
--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -293,7 +293,7 @@ def test_download_job_result():
         {"str": "value1", "int": 1, "float": 2.3},
         {"str": "value3", "int": 4, "float": 5.6},
     ]
-    body_download = gzipb(msgpackb(data))
+    body_download = msgpackb(data)
     td.get = mock.MagicMock()
     td.get.side_effect = [make_response(200, body), make_response(206, body_download)]
     with tempfile.TemporaryDirectory() as tempdir:
@@ -301,10 +301,10 @@ def test_download_job_result():
         td.download_job_result(12345, temp)
         td.get.assert_any_call("/v3/job/show/12345")
         td.get.assert_any_call(
-            "/v3/job/result/12345?format=msgpack.gz", headers={"Range": "bytes=0-21"}
+            "/v3/job/result/12345?format=msgpack", headers={"Range": "bytes=0-21"}
         )
         with open(temp, "rb") as f:
-            result = msgunpackb(gunzipb(f.read()))
+            result = msgunpackb(f.read())
             assert result == data
 
 

--- a/tdclient/test/job_api_test.py
+++ b/tdclient/test/job_api_test.py
@@ -242,7 +242,7 @@ def test_job_result_msgpack_each_store_tmpfile_success():
         }
     """
     rows = [["foo", 123], ["bar", 456], ["baz", 789]]
-    body_download = gzipb(msgpackb(rows))
+    body_download = msgpackb(rows)
     td.get = mock.MagicMock()
     td.get.side_effect = [
         make_response(200, body),
@@ -252,7 +252,7 @@ def test_job_result_msgpack_each_store_tmpfile_success():
     for row in td.job_result_format_each(12345, "msgpack", store_tmpfile=True):
         result.append(row)
     td.get.assert_called_with(
-        "/v3/job/result/12345?format=msgpack.gz", headers={"Range": "bytes=0-21"}
+        "/v3/job/result/12345?format=msgpack", headers={"Range": "bytes=0-21"}
     )
     assert result == rows
 


### PR DESCRIPTION
### Context

Fixes an obscure bug(?) where certain tables being downloaded as zipped `msgpack` files would not be read correctly by `gzip` during unpacking, if temporary file storage is used. The files would seemingly become corrupt, causing the following stacktrace:

```
File ~/.pyenv/versions/3.11.10/lib/python3.11/site-packages/tdclient/client.py:353, in Client.job_result_format_each(self, job_id, format, header, store_tmpfile, num_threads)
    336 def job_result_format_each(
    337     self, job_id, format, header=False, store_tmpfile=False, num_threads=4
    338 ):
    339     """
    340     Args:
    341         job_id (str): job id
   (...)
    351          an iterator of rows in result set
    352     """
--> 353     for row in self.api.job_result_format_each(
    354         job_id,
    355         format,
    356         header=header,
    357         store_tmpfile=store_tmpfile,
    358         num_threads=num_threads,
    359     ):
    360         yield row

File ~/.pyenv/versions/3.11.10/lib/python3.11/site-packages/tdclient/job_api.py:269, in JobAPI.job_result_format_each(self, job_id, format, header, store_tmpfile, num_threads)
    265     with gzip.GzipFile(path, "rb") as f:
    266         unpacker = msgpack.Unpacker(
    267             f, raw=False, max_buffer_size=1000 * 1024**2
    268         )
--> 269         for row in unpacker:
    270             yield row
    271 return

File msgpack/_unpacker.pyx:540, in msgpack._cmsgpack.Unpacker.__next__()

File msgpack/_unpacker.pyx:474, in msgpack._cmsgpack.Unpacker._unpack()

File msgpack/_unpacker.pyx:448, in msgpack._cmsgpack.Unpacker.read_from_file()

File ~/.pyenv/versions/3.11.10/lib/python3.11/gzip.py:301, in GzipFile.read(self, size)
    299     import errno
    300     raise OSError(errno.EBADF, "read() on write-only GzipFile object")
--> 301 return self._buffer.read(size)

File ~/.pyenv/versions/3.11.10/lib/python3.11/_compression.py:68, in DecompressReader.readinto(self, b)
     66 def readinto(self, b):
     67     with memoryview(b) as view, view.cast("B") as byte_view:
---> 68         data = self.read(len(byte_view))
     69         byte_view[:len(data)] = data
     70     return len(data)

File ~/.pyenv/versions/3.11.10/lib/python3.11/gzip.py:518, in _GzipReader.read(self, size)
    516         break
    517     if buf == b"":
--> 518         raise EOFError("Compressed file ended before the "
    519                        "end-of-stream marker was reached")
    521 self._add_read_data( uncompress )
    522 self._pos += len(uncompress)

EOFError: Compressed file ended before the end-of-stream marker was reached
```

### Fix

While many things could technically affect this, such as the way chunks are written to the temporary files, etc. - the fact that this wasn't previously an issue alluded to a dependency bug or change in behavior. Attempting to alleviate by saving the temp files without the `.gz` extension and reading using `open()` instead of `gzip` fixes the issue.

### Notes

- This didn't occur during downloads previously. It seems to have only started happening recently and only on some tables (>1M rows, we haven't seen occurrences on smaller ones.)
- Until a further investigation is performed, we cannot say for certain why the behavior arises. At the very least, we can issue a simple fix and re-investigate again.